### PR TITLE
Implement Calculus for CubicSpline

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ maintenance = { status = "actively-developed" }
 [dependencies]
 csv = "1.1"
 rand = "0.7"
-special = "0.8"
+special = { version = "0.8", optional = true }
 indexmap = { version = "1.3", optional = true }
 netcdf = { version = "0.2", optional = true, default_features = false, features = ["indexmap"] }
 pyo3 = { version = "0.8", optional = true }
@@ -31,7 +31,7 @@ serde = { version = "1.0", features = ["derive"], optional = true }
 rustdoc-args = [ "--html-in-header", "katex-header.html" ]
 
 [features]
-default = []
+default = ["special"]
 O3 = ["blas", "lapack", "packed_simd"]
 plot = ["pyo3"]
 dataframe = ["netcdf", "indexmap"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,9 +205,11 @@ pub use util::api::*;
 //pub use numerical::gauss_legendre::*;
 
 #[allow(unused_imports)]
+#[cfg(feature = "special")]
 pub use statistics::dist::*;
 
 #[allow(unused_imports)]
+#[cfg(feature = "special")]
 pub use special::function::*;
 
 #[allow(unused_imports)]

--- a/src/numerical/spline.rs
+++ b/src/numerical/spline.rs
@@ -4,6 +4,7 @@ use std::ops::Range;
 use operation::extra_ops::PowOps;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
+use std::convert::{From, Into};
 #[allow(unused_imports)]
 use structure::matrix::*;
 #[allow(unused_imports)]
@@ -227,14 +228,38 @@ impl std::convert::Into<Vec<Polynomial>> for CubicSpline {
     }
 }
 
-impl std::convert::From<Vec<(Range<f64>, Polynomial)>> for CubicSpline {
+impl From<Vec<(Range<f64>, Polynomial)>> for CubicSpline {
     fn from(polynomials: Vec<(Range<f64>, Polynomial)>) -> Self {
         CubicSpline { polynomials }
     }
 }
 
-impl std::convert::Into<Vec<(Range<f64>, Polynomial)>> for CubicSpline {
+impl Into<Vec<(Range<f64>, Polynomial)>> for CubicSpline {
     fn into(self) -> Vec<(Range<f64>, Polynomial)> {
         self.polynomials
+    }
+}
+
+impl Calculus for CubicSpline {
+    fn diff(&self) -> Self {
+        let mut polynomials: Vec<(Range<f64>, Polynomial)> = self.clone().into();
+
+        polynomials = polynomials
+            .into_iter()
+            .map(|(r, poly)| (r, poly.diff()))
+            .collect();
+
+        Self::from(polynomials)
+    }
+
+    fn integral(&self) -> Self {
+        let mut polynomials: Vec<(Range<f64>, Polynomial)> = self.clone().into();
+
+        polynomials = polynomials
+            .into_iter()
+            .map(|(r, poly)| (r, poly.integral()))
+            .collect();
+
+        Self::from(polynomials)
     }
 }

--- a/src/special/mod.rs
+++ b/src/special/mod.rs
@@ -1,4 +1,5 @@
 //! Special function module
 
+#[cfg(feature = "special")]
 pub mod function;
 pub mod legendre;

--- a/src/statistics/mod.rs
+++ b/src/statistics/mod.rs
@@ -5,6 +5,7 @@
 //! * Simple Random Number Generator - `rand.rs`
 //! * Basic probabilistic operations - `ops.rs`
 
+#[cfg(feature = "special")]
 pub mod dist;
 pub mod ops;
 pub mod rand;

--- a/src/util/print.rs
+++ b/src/util/print.rs
@@ -3,8 +3,12 @@
 use operation::number::Number;
 use rand::distributions::uniform::SampleUniform;
 #[allow(unused_imports)]
+#[cfg(feature = "special")]
 use statistics::dist::*;
 use std::fmt::Debug;
+#[allow(unused_imports)]
+#[cfg(feature = "dataframe")]
+use structure::dataframe::*;
 #[allow(unused_imports)]
 use structure::dual::*;
 #[allow(unused_imports)]
@@ -17,9 +21,6 @@ use structure::multinomial::*;
 use structure::polynomial::*;
 #[allow(unused_imports)]
 use structure::vector::*;
-#[allow(unused_imports)]
-#[cfg(feature = "dataframe")]
-use structure::dataframe::*;
 
 pub trait Printable {
     fn print(&self);
@@ -129,12 +130,14 @@ impl Printable for HyperDual {
     }
 }
 
+#[cfg(feature = "special")]
 impl<T: Debug + PartialOrd + SampleUniform + Copy + Into<f64>> Printable for OPDist<T> {
     fn print(&self) {
         println!("{:?}", self);
     }
 }
 
+#[cfg(feature = "special")]
 impl<T: Debug + PartialOrd + SampleUniform + Copy + Into<f64>> Printable for TPDist<T> {
     fn print(&self) {
         println!("{:?}", self);

--- a/tests/matrix.rs
+++ b/tests/matrix.rs
@@ -53,6 +53,7 @@ fn test_row() {
     assert_eq!(a.row(0), c!(1, 2));
 }
 
+#[cfg(feature = "special")]
 #[test]
 fn test_print() {
     let op = Bernoulli(0);


### PR DESCRIPTION
This PR add the trait implementation `Calculus` for `CubicSpline`. Additionally, make special an optional dependency to be able to compile for wasm in order to use Peroxide in the browser.