### PR TITLE
Update `lambert_w` crate to version 0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ serde = { version = "1.0", features = ["derive"], optional = true }
 json = { version = "0.12", optional = true }
 arrow2 = { version = "0.18", features = ["io_parquet", "io_parquet_compression"], optional = true }
 num-complex = { version = "0.4", optional = true }
-lambert_w = { version = "0.3.0", default-features = false, features = ["24bits", "50bits"] }
+lambert_w = { version = "0.4.0", default-features = false, features = ["24bits", "50bits"] }
 
 [package.metadata.docs.rs]
 rustdoc-args = [ "--html-in-header", "katex-header.html", "--cfg", "docsrs"]

--- a/src/special/function.rs
+++ b/src/special/function.rs
@@ -135,7 +135,6 @@ pub fn lambert_w0(z: f64, mode: LambertWAccuracyMode) -> f64 {
         LambertWAccuracyMode::Precise => lambert_w::lambert_w_0(z),
         LambertWAccuracyMode::Simple => lambert_w::sp_lambert_w_0(z),
     }
-    .unwrap_or(f64::NAN)
 }
 
 /// The secondary branch of the Lambert W function, W_-1(`z`).
@@ -155,7 +154,6 @@ pub fn lambert_wm1(z: f64, mode: LambertWAccuracyMode) -> f64 {
         LambertWAccuracyMode::Precise => lambert_w::lambert_w_m1(z),
         LambertWAccuracyMode::Simple => lambert_w::sp_lambert_w_m1(z),
     }
-    .unwrap_or(f64::NAN)
 }
 
 /// Decides the accuracy mode of the Lambert W functions.


### PR DESCRIPTION
I decided that the way errors are handled in `peroxide` (return NAN when given input outside the domain, and not None) is better, as it is more in line with how it's done in the standard library (for e.g. [f64::asin()](https://doc.rust-lang.org/std/primitive.f64.html#method.asin)). I updated `lambert_w` to do that and now make this PR to use the updated functions.

This is a very low priority PR, as it only changes internal stuff in a way that doesn't affect the API or the performance.