### PR TITLE
IMPL: generic and complex integration

### DIFF
--- a/src/complex/integral.rs
+++ b/src/complex/integral.rs
@@ -1,0 +1,53 @@
+use crate::complex::C64;
+use crate::numerical::integral::{GKIntegrable, GLKIntegrable, NCIntegrable};
+use crate::structure::polynomial::{lagrange_polynomial, Calculus, Polynomial};
+
+// Newton Cotes Quadrature for Complex Functions of one Real Variable
+impl NCIntegrable for C64 {
+    type NodeY = (Vec<f64>, Vec<f64>);
+    type NCPolynomial = (Polynomial, Polynomial);
+
+    fn compute_node_y<F>(f: F, node_x: &[f64]) -> Self::NodeY
+    where
+        F: Fn(f64) -> Self,
+    {
+        node_x
+            .iter()
+            .map(|x| {
+                let z = f(*x);
+                (z.re, z.im)
+            })
+            .unzip()
+    }
+
+    fn compute_polynomial(node_x: &[f64], node_y: &Self::NodeY) -> Self::NCPolynomial {
+        (
+            lagrange_polynomial(node_x.to_vec(), node_y.0.to_vec()),
+            lagrange_polynomial(node_x.to_vec(), node_y.1.to_vec()),
+        )
+    }
+
+    fn integrate_polynomial(p: &Self::NCPolynomial) -> Self::NCPolynomial {
+        (p.0.integral(), p.1.integral())
+    }
+
+    fn evaluate_polynomial(p: &Self::NCPolynomial, x: f64) -> Self {
+        p.0.eval(x) + C64::I * p.1.eval(x)
+    }
+}
+
+// Gauss Lagrange and Kronrod Quadrature for Complex Functions of one Real Variable
+impl GLKIntegrable for C64 {
+    const ZERO: Self = C64::ZERO;
+}
+
+// Gauss Kronrod Quadrature for Complex Functions of one Real Variable
+impl GKIntegrable for C64 {
+    fn is_finite(&self) -> bool {
+        C64::is_finite(*self)
+    }
+
+    fn gk_norm(&self) -> f64 {
+        self.norm()
+    }
+}

--- a/src/complex/mod.rs
+++ b/src/complex/mod.rs
@@ -2,4 +2,5 @@ use num_complex::Complex;
 
 pub type C64 = Complex<f64>;
 
+pub mod integral;
 pub mod vector;

--- a/src/numerical/integral.rs
+++ b/src/numerical/integral.rs
@@ -1,4 +1,4 @@
-use crate::structure::polynomial::{lagrange_polynomial, Calculus};
+use crate::structure::polynomial::{lagrange_polynomial, Calculus, Polynomial};
 use crate::traits::fp::FPVector;
 use crate::util::non_macro::seq;
 
@@ -132,6 +132,78 @@ impl Integral {
     }
 }
 
+// Types that can be integrated using Newton Cotes Quadrature
+pub trait NCIntegrable: std::ops::Sub<Self, Output = Self> + Sized {
+    type NodeY;
+    type NCPolynomial;
+
+    fn compute_node_y<F>(f: F, node_x: &[f64]) -> Self::NodeY
+    where
+        F: Fn(f64) -> Self;
+
+    fn compute_polynomial(node_x: &[f64], node_y: &Self::NodeY) -> Self::NCPolynomial;
+
+    fn integrate_polynomial(p: &Self::NCPolynomial) -> Self::NCPolynomial;
+
+    fn evaluate_polynomial(p: &Self::NCPolynomial, x: f64) -> Self;
+}
+
+impl NCIntegrable for f64 {
+    type NodeY = Vec<f64>;
+    type NCPolynomial = Polynomial;
+
+    fn compute_node_y<F>(f: F, node_x: &[f64]) -> Vec<f64>
+    where
+        F: Fn(f64) -> Self,
+    {
+        node_x.to_vec().fmap(|x| f(x))
+    }
+
+    fn compute_polynomial(node_x: &[f64], node_y: &Vec<f64>) -> Polynomial {
+        lagrange_polynomial(node_x.to_vec(), node_y.to_vec())
+    }
+
+    fn integrate_polynomial(p: &Polynomial) -> Polynomial {
+        p.integral()
+    }
+
+    fn evaluate_polynomial(p: &Polynomial, x: f64) -> Self {
+        p.eval(x)
+    }
+}
+
+// Types that can be integrated using Gauss Lagrange or Kronrod Quadrature
+pub trait GLKIntegrable:
+    std::ops::Add<Self, Output = Self> + std::ops::Mul<f64, Output = Self> + Sized
+{
+    const ZERO: Self;
+}
+
+impl GLKIntegrable for f64 {
+    const ZERO: Self = 0f64;
+}
+
+// Types that can be integrated using Gauss Kronrod Quadrature
+pub trait GKIntegrable: GLKIntegrable + std::ops::Sub<Self, Output = Self> + Sized + Clone {
+    fn is_finite(&self) -> bool;
+
+    fn gk_norm(&self) -> f64;
+
+    fn is_within_tol(&self, tol: f64) -> bool {
+        self.gk_norm() < tol
+    }
+}
+
+impl GKIntegrable for f64 {
+    fn is_finite(&self) -> bool {
+        f64::is_finite(*self)
+    }
+
+    fn gk_norm(&self) -> f64 {
+        self.abs()
+    }
+}
+
 /// Numerical Integration
 ///
 /// # Description
@@ -159,29 +231,31 @@ impl Integral {
 ///     * `G20K41R`
 ///     * `G25K51R`
 ///     * `G30K61R`
-pub fn integrate<F>(f: F, (a, b): (f64, f64), method: Integral) -> f64
+pub fn integrate<F, Y>(f: F, (a, b): (f64, f64), method: Integral) -> Y
 where
-    F: Fn(f64) -> f64 + Copy,
+    F: Fn(f64) -> Y + Copy,
+    Y: GKIntegrable + NCIntegrable,
 {
     match method {
         Integral::GaussLegendre(n) => gauss_legendre_quadrature(f, n, (a, b)),
         Integral::NewtonCotes(n) => newton_cotes_quadrature(f, n, (a, b)),
-        method => gauss_kronrod_quadrature(f, (a,b), method),
+        method => gauss_kronrod_quadrature(f, (a, b), method),
     }
 }
 
 /// Newton Cotes Quadrature
-pub fn newton_cotes_quadrature<F>(f: F, n: usize, (a, b): (f64, f64)) -> f64
+pub fn newton_cotes_quadrature<F, Y>(f: F, n: usize, (a, b): (f64, f64)) -> Y
 where
-    F: Fn(f64) -> f64,
+    F: Fn(f64) -> Y,
+    Y: NCIntegrable,
 {
     let h = (b - a) / (n as f64);
     let node_x = seq(a, b, h);
-    let node_y = node_x.fmap(|x| f(x));
-    let p = lagrange_polynomial(node_x, node_y);
-    let q = p.integral();
+    let node_y = Y::compute_node_y(f, &node_x);
+    let p = Y::compute_polynomial(&node_x, &node_y);
+    let q = Y::integrate_polynomial(&p);
 
-    q.eval(b) - q.eval(a)
+    Y::evaluate_polynomial(&q, b) - Y::evaluate_polynomial(&q, a)
 }
 
 /// Gauss Legendre Quadrature
@@ -195,11 +269,12 @@ where
 /// # Reference
 /// * A. N. Lowan et al. (1942)
 /// * [Keisan Online Calculator](https://keisan.casio.com/exec/system/1329114617)
-pub fn gauss_legendre_quadrature<F>(f: F, n: usize, (a, b): (f64, f64)) -> f64
+pub fn gauss_legendre_quadrature<F, Y>(f: F, n: usize, (a, b): (f64, f64)) -> Y
 where
-    F: Fn(f64) -> f64,
+    F: Fn(f64) -> Y,
+    Y: GLKIntegrable,
 {
-    (b - a) / 2f64 * unit_gauss_legendre_quadrature(|x| f(x * (b - a) / 2f64 + (a + b) / 2f64), n)
+    unit_gauss_legendre_quadrature(|x| f(x * (b - a) / 2f64 + (a + b) / 2f64), n) * ((b - a) / 2f64)
 }
 
 /// Gauss Kronrod Quadrature
@@ -215,16 +290,17 @@ where
 /// * arXiv: [1003.4629](https://arxiv.org/abs/1003.4629)
 /// * [Keisan Online Calculator](https://keisan.casio.com/exec/system/1329114617)
 #[allow(non_snake_case)]
-pub fn gauss_kronrod_quadrature<F, T, S>(f: F, (a, b): (T, S), method: Integral) -> f64
+pub fn gauss_kronrod_quadrature<F, T, S, Y>(f: F, (a, b): (T, S), method: Integral) -> Y
 where
-     F: Fn(f64) -> f64 + Copy,
-     T: Into<f64>,
-     S: Into<f64>,
+    F: Fn(f64) -> Y + Copy,
+    T: Into<f64>,
+    S: Into<f64>,
+    Y: GKIntegrable,
 {
     let (g, k) = method.get_gauss_kronrod_order();
     let tol = method.get_tol();
     let max_iter = method.get_max_iter();
-    let mut I = 0f64;
+    let mut I = Y::ZERO;
     let mut S: Vec<(f64, f64, f64, u32)> = vec![];
     S.push((a.into(), b.into(), tol, max_iter));
 
@@ -235,15 +311,15 @@ where
                 let K = kronrod_quadrature(f, k as usize, (a, b));
                 let c = (a + b) / 2f64;
                 let tol_curr = if method.is_relative() {
-                    tol * G
+                    tol * G.gk_norm()
                 } else {
                     tol
                 };
-                if (G - K).abs() < tol_curr || a == b || max_iter == 0 {
-                    if ! G.is_finite() {
+                if (G.clone() - K).is_within_tol(tol_curr) || a == b || max_iter == 0 {
+                    if !G.is_finite() {
                         return G;
                     }
-                    I += G;
+                    I = I + G;
                 } else {
                     S.push((a, c, tol / 2f64, max_iter - 1));
                     S.push((c, b, tol / 2f64, max_iter - 1));
@@ -255,24 +331,26 @@ where
     I
 }
 
-pub fn kronrod_quadrature<F>(f: F, n: usize, (a, b): (f64, f64)) -> f64 
+pub fn kronrod_quadrature<F, Y>(f: F, n: usize, (a, b): (f64, f64)) -> Y
 where
-    F: Fn(f64) -> f64,
+    F: Fn(f64) -> Y,
+    Y: GLKIntegrable,
 {
-    (b - a) / 2f64 * unit_kronrod_quadrature(|x| f(x * (b-a) / 2f64 + (a + b) / 2f64), n)   
+    unit_kronrod_quadrature(|x| f(x * (b - a) / 2f64 + (a + b) / 2f64), n) * ((b - a) / 2f64)
 }
 
 // =============================================================================
 // Gauss Legendre Backends
 // =============================================================================
-fn unit_gauss_legendre_quadrature<F>(f: F, n: usize) -> f64
+fn unit_gauss_legendre_quadrature<F, Y>(f: F, n: usize) -> Y
 where
-    F: Fn(f64) -> f64,
+    F: Fn(f64) -> Y,
+    Y: GLKIntegrable,
 {
     let (a, x) = gauss_legendre_table(n);
-    let mut s = 0f64;
+    let mut s = Y::ZERO;
     for i in 0..a.len() {
-        s += a[i] * f(x[i]);
+        s = s + f(x[i]) * a[i];
     }
     s
 }
@@ -378,14 +456,15 @@ fn gauss_legendre_table(n: usize) -> (Vec<f64>, Vec<f64>) {
 // Gauss Kronrod Backends
 // =============================================================================
 
-fn unit_kronrod_quadrature<F>(f: F, n: usize) -> f64
+fn unit_kronrod_quadrature<F, Y>(f: F, n: usize) -> Y
 where
-    F: Fn(f64) -> f64,
+    F: Fn(f64) -> Y,
+    Y: GLKIntegrable,
 {
-    let (a,x) = kronrod_table(n);
-    let mut s = 0f64;
-    for i in 0 .. a.len() {
-        s += a[i] * f(x[i]);
+    let (a, x) = kronrod_table(n);
+    let mut s = Y::ZERO;
+    for i in 0..a.len() {
+        s = s + f(x[i]) * a[i];
     }
     s
 }
@@ -414,28 +493,28 @@ fn kronrod_table(n: usize) -> (Vec<f64>, Vec<f64>) {
 
     match n % 2 {
         0 => {
-            for i in 0 .. ref_node.len() {
+            for i in 0..ref_node.len() {
                 result_node[i] = ref_node[i];
                 result_weight[i] = ref_weight[i];
             }
 
-            for i in ref_node.len() .. n {
-                result_node[i] = -ref_node[n-i-1];
-                result_weight[i] = ref_weight[n-i-1];
+            for i in ref_node.len()..n {
+                result_node[i] = -ref_node[n - i - 1];
+                result_weight[i] = ref_weight[n - i - 1];
             }
         }
         1 => {
-            for i in 0 .. ref_node.len() {
+            for i in 0..ref_node.len() {
                 result_node[i] = ref_node[i];
                 result_weight[i] = ref_weight[i];
             }
 
-            for i in ref_node.len() .. n {
-                result_node[i] = -ref_node[n-i];
-                result_weight[i] = ref_weight[n-i];
+            for i in ref_node.len()..n {
+                result_node[i] = -ref_node[n - i];
+                result_weight[i] = ref_weight[n - i];
             }
         }
-        _ => unreachable!()
+        _ => unreachable!(),
     }
     (result_weight, result_node)
 }
@@ -922,7 +1001,7 @@ const LEGENDRE_WEIGHT_25: [f64; 13] = [
     0.054904695975835192,
     0.040939156701306313,
     0.026354986615032137,
-    0.011393798501026288,    
+    0.011393798501026288,
 ];
 const LEGENDRE_WEIGHT_26: [f64; 13] = [
     0.118321415279262277,


### PR DESCRIPTION
This draft PR implements integration of complex functions of one real variable. To do so, it first makes integration generic enough and then implements it for both real and complex functions. One of the guiding principles of this PR was not to change the pre-existing APIs. Of course, I also didn't change the current implementation of real integrals.

#### Theory

Since the integral of a complex function can be computed by splitting it into its real and imaginary part and separately computing two real integrals, all the integration methods currently defined in peroxide can be easily lifted to complex integration (with some qualifications needed for Gauss-Kronrod quadrature, which I'll discuss later). It would make little sense to re-define quadratures from scratch for complex number. The most logic way to proceed is making quadratures generic enough that they apply to both real and complex functions, and then implement the quadratures for both.

As to what type should be the subject of the generics, instead of defining a `RealOrComplex` trait or using `Num` from the `num` crate, I decided to go with an implementation which would make it possible to easily extend integration to types like vectors or matrices. Just like complex numbers, by linearity, the integral of vector/matrix functions of one real variable can be computed by evaluating a certain number of real integrals. By not committing to "numbers", but using more general traits instead, integration is easily implemented for these types too.

#### Implementation

How general? I'd say as general as the single quadratures needs them to be. For this reason I introduced three new traits: `NCIntegrable`, `GLKIntegrable` and `GKIntegrable`. These represent, respectively, types (which are the codomain of functions) which can be integrated using the Newton-Cotes quadrature, the Gauss-Legendre or the Kronrod quadrature, and the Gauss-Kronrod quadrature. Gauss-Legendre and Kronrod in theory should be kept separate, but computing these quadratures requires performing the very same operations (modulo tables), so in practice they coincide. Each of these traits is fairly easy to implement and only defines functions/constants which are actually needed to compute the quadratures. Keeping them separate leaves room, in the future, to implement integration for types which may not be integrable with some of the quadratures mentioned above, but that can still be integrated using the others. All traits are public so that users of the library can implement them for their own types.

Having defined the three traits, the building blocks of peroxide's integration routines, that is, `fn newton_cotes_quadrature`, `fn gauss_kronrod_quadrature`, `fn unit_gauss_legendre_quadrature` and `fn unit_kronrod_quadrature` are generalized to make use of those traits. All other functions are just wrappers around these, so they don't need more changes (asides from having to move some commutative operands from left to right to deal with the stupidity of rust being unable to overload operations on the left). In particular, switching to generic functions the way I did does not break the API and one will be able to use, for complex functions, the same library functions used for real ones.

#### Details (not all of them)

This PR introduces two associated types, `NCIntegrable::{NodeY,PolynomialY}`. These generalize `node_y: Vec<f64>` and `p: Polynomial` for Newton-Cotes integration. Implementing `NCIntegrable` requires defining how to compute a `NodeY` and a `PolynomialY`, and how to integrate the latter and evaluate it at a point. For types like complex numbers, vectors, matrices, etc., these operations should simply be duplicated over the codomain's degrees of freedom (e.g. real/imaginary part for complex numbers, single entries in vectors/matrices). Evaluation then rearranges the result in the correct format (e.g. the real and imaginary part are independently evaluated and then combined to obtain a single complex number; for vector/matrices the entries would be evaluated independently and then combined into a vector/matrix of the same format etc.)

Gauss-Kronrod quadrature works with a single tolerance, whereas the codomain of complex/vector/matrix integrals has 2 or more degrees of freedom. What to do with the tolerance depends on the implementation, and this is reflected in the existence of a `is_within_tol` trait function whose purpose is to say whether a certain value (real/complex number, vector, matrix, etc.) is within the specified tolerance. `is_within_tol` has a default implementation, which declares the value to be within tolerance if its `gk_norm` is. The `gk_norm` is the value used to compute relative tolerances and generalizes the absolute value of real numbers. For complex numbers it is taken to be equal to their modulus, and `is_within_tol` is left to its default. What this means is this PR computes the Gauss-Kronrod quadrature of complex functions by applying its tolerance to the modulus of `G-K`. One alternative could be using a different `gk_norm`, like `max(|z.re|, |z.im|)`.

#### Notes

Some of the changes introduced by this MR are whitespace changes. This is because the crate is not formatted using `cargo fmt`. I'd ask you to please do so, as it makes contributing to the project much easier. I'd then rebase my changes on the formatted versions.

One example of using the functionality provided by this PR is [here](https://github.com/GComitini/qcd-sme-rs/tree/mainline-complex-integration).