### PR TITLE
Rand matrix refactor

### DIFF
--- a/src/util/non_macro.rs
+++ b/src/util/non_macro.rs
@@ -17,7 +17,7 @@
 //! - linspace_with_precision
 //! - rand
 //! - rand_with_rng
-//! - rand_with_distr
+//! - rand_with_dist
 //!
 //! # Numpy like non-macro functions
 //!
@@ -330,7 +330,7 @@ pub fn rand(r: usize, c: usize) -> Matrix {
 /// Range = from 0 to 1
 pub fn rand_with_rng<R: Rng>(r: usize, c: usize, rng: &mut R) -> Matrix {
     let uniform = Uniform::new_inclusive(0f64, 1f64);
-    rand_with_distr(r, c, rng, uniform)
+    rand_with_dist(r, c, rng, uniform)
 }
 
 /// Rand matrix with specific rng and distribution
@@ -338,8 +338,8 @@ pub fn rand_with_rng<R: Rng>(r: usize, c: usize, rng: &mut R) -> Matrix {
 /// # Description
 ///
 /// Any range
-pub fn rand_with_distr<T: Into<f64>, R: Rng, D: Distribution<T>>(r: usize, c: usize, rng: &mut R, distr: D) -> Matrix {
-    matrix(rng.sample_iter(distr).take(r*c).collect(), r, c, Row)
+pub fn rand_with_dist<T: Into<f64>, R: Rng, D: Distribution<T>>(r: usize, c: usize, rng: &mut R, dist: D) -> Matrix {
+    matrix(rng.sample_iter(dist).take(r*c).collect(), r, c, Row)
 }
 
 // ┌─────────────────────────────────────────────────────────┐

--- a/src/util/non_macro.rs
+++ b/src/util/non_macro.rs
@@ -15,9 +15,9 @@
 //! - zeros_shape
 //! - linspace
 //! - linspace_with_precision
-//! - randn
-//! - randn_with_rng
-//! - randn_with_distr
+//! - rand
+//! - rand_with_rng
+//! - rand_with_distr
 //!
 //! # Numpy like non-macro functions
 //!
@@ -318,9 +318,9 @@ where
 /// # Description
 ///
 /// Range = from 0 to 1
-pub fn randn(r: usize, c: usize) -> Matrix {
+pub fn rand(r: usize, c: usize) -> Matrix {
     let mut rng = thread_rng();
-    randn_with_rng(r, c, &mut rng)
+    rand_with_rng(r, c, &mut rng)
 }
 
 /// Rand matrix with specific rng
@@ -328,9 +328,9 @@ pub fn randn(r: usize, c: usize) -> Matrix {
 /// # Description
 ///
 /// Range = from 0 to 1
-pub fn randn_with_rng<R: Rng>(r: usize, c: usize, rng: &mut R) -> Matrix {
+pub fn rand_with_rng<R: Rng>(r: usize, c: usize, rng: &mut R) -> Matrix {
     let uniform = Uniform::new_inclusive(0f64, 1f64);
-    randn_with_distr(r, c, rng, uniform)
+    rand_with_distr(r, c, rng, uniform)
 }
 
 /// Rand matrix with specific rng and distribution
@@ -338,7 +338,7 @@ pub fn randn_with_rng<R: Rng>(r: usize, c: usize, rng: &mut R) -> Matrix {
 /// # Description
 ///
 /// Any range
-pub fn randn_with_distr<T: Into<f64>, R: Rng, D: Distribution<T>>(r: usize, c: usize, rng: &mut R, distr: D) -> Matrix {
+pub fn rand_with_distr<T: Into<f64>, R: Rng, D: Distribution<T>>(r: usize, c: usize, rng: &mut R, distr: D) -> Matrix {
     matrix(rng.sample_iter(distr).take(r*c).collect(), r, c, Row)
 }
 

--- a/src/util/non_macro.rs
+++ b/src/util/non_macro.rs
@@ -15,8 +15,9 @@
 //! - zeros_shape
 //! - linspace
 //! - linspace_with_precision
-//! - rand
-//! - rand_with_rng
+//! - randn
+//! - randn_with_rng
+//! - randn_with_distr
 //!
 //! # Numpy like non-macro functions
 //!
@@ -31,6 +32,7 @@
 
 extern crate rand;
 use self::rand::prelude::*;
+use rand_distr::{Uniform, Distribution};
 use crate::structure::{
     matrix::Shape::{Col, Row},
     matrix::{matrix, Matrix, Shape},
@@ -316,15 +318,9 @@ where
 /// # Description
 ///
 /// Range = from 0 to 1
-pub fn rand(r: usize, c: usize) -> Matrix {
-    let mut m = zeros(r, c);
+pub fn randn(r: usize, c: usize) -> Matrix {
     let mut rng = thread_rng();
-    for i in 0..r {
-        for j in 0..c {
-            m[(i, j)] = rng.gen_range(0f64..=1f64);
-        }
-    }
-    m
+    randn_with_rng(r, c, &mut rng)
 }
 
 /// Rand matrix with specific rng
@@ -332,14 +328,18 @@ pub fn rand(r: usize, c: usize) -> Matrix {
 /// # Description
 ///
 /// Range = from 0 to 1
-pub fn rand_with_rng<R: Rng>(r: usize, c: usize, rng: &mut R) -> Matrix {
-    let mut m = zeros(r, c);
-    for i in 0..r {
-        for j in 0..c {
-            m[(i, j)] = rng.gen_range(0f64..=1f64);
-        }
-    }
-    m
+pub fn randn_with_rng<R: Rng>(r: usize, c: usize, rng: &mut R) -> Matrix {
+    let uniform = Uniform::new_inclusive(0f64, 1f64);
+    randn_with_distr(r, c, rng, uniform)
+}
+
+/// Rand matrix with specific rng and distribution
+///
+/// # Description
+///
+/// Any range
+pub fn randn_with_distr<T: Into<f64>, R: Rng, D: Distribution<T>>(r: usize, c: usize, rng: &mut R, distr: D) -> Matrix {
+    matrix(rng.sample_iter(distr).take(r*c).collect(), r, c, Row)
 }
 
 // ┌─────────────────────────────────────────────────────────┐


### PR DESCRIPTION
Hi. This PR refactors the functions initializing a random matrix:

1. new method `randn_with_distr` that accepts a `Distribution<T>` from `rand`
2. the two previous methods make use of default constructor and are more compact
3. ~`rand` has been named `randn` in all functions to be in line with other programs (MATLAB, Julia, etc)~

Let me know what you think.