### PR TITLE
Update `puruspe` dependency, remove `lambert_w` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ csv = { version = "1.3", optional = true, default-features = false }
 rand = { version = "0.8", features = ["small_rng"] }
 rand_distr = "0.4"
 order-stat = "0.1"
-puruspe = "0.2"
+puruspe = "0.3"
 matrixmultiply = { version = "0.3", features = ["threading"] }
 peroxide-ad = "0.3"
 peroxide-num = "0.1"
@@ -52,10 +52,6 @@ arrow2 = { version = "0.18", features = [
     "io_parquet_compression",
 ], optional = true }
 num-complex = { version = "0.4", optional = true }
-lambert_w = { version = "0.4.0", default-features = false, features = [
-    "24bits",
-    "50bits",
-] }
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--html-in-header", "katex-header.html", "--cfg", "docsrs"]

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,6 +1,6 @@
 # Release 0.37.10 (in progress)
 
-- Update `lambert_w` dependency to `0.4.0` [#66](https://github.com/Axect/Peroxide/pull/66) (Thanks to [@JSorngard](https://github.com/JSorngard))
+- Update `puruspe` dependency to `0.3.0`, remove `lambert_w` dependency [#79](https://github.com/Axect/Peroxide/pull/79) (Thanks to [@JSorngard](https://github.com/JSorngard))
 
 # Release 0.37.9 (2024-07-31)
 

--- a/src/special/function.rs
+++ b/src/special/function.rs
@@ -125,15 +125,15 @@ pub fn phi(x: f64) -> f64 {
 /// Use [`Precise`](LambertWAccuracyMode::Precise) for 50 bits of accuracy and the [`Simple`](LambertWAccuracyMode::Simple) mode 
 /// for only 24 bits, but with faster execution time.
 /// 
-/// Wrapper of the `lambert_w_0` and `sp_lambert_w_0` functions of the `lambert_w` crate.
+/// Wrapper of the `lambert_w_0` and `sp_lambert_w_0` functions of the `puruspe` crate.
 ///
 /// # Reference
 ///
 /// [Toshio Fukushima, Precise and fast computation of Lambert W function by piecewise minimax rational function approximation with variable transformation](https://www.researchgate.net/publication/346309410_Precise_and_fast_computation_of_Lambert_W_function_by_piecewise_minimax_rational_function_approximation_with_variable_transformation)
 pub fn lambert_w0(z: f64, mode: LambertWAccuracyMode) -> f64 {
     match mode {
-        LambertWAccuracyMode::Precise => lambert_w::lambert_w_0(z),
-        LambertWAccuracyMode::Simple => lambert_w::sp_lambert_w_0(z),
+        LambertWAccuracyMode::Precise => puruspe::lambert_w0(z),
+        LambertWAccuracyMode::Simple => puruspe::sp_lambert_w0(z),
     }
 }
 
@@ -144,15 +144,15 @@ pub fn lambert_w0(z: f64, mode: LambertWAccuracyMode) -> f64 {
 /// Use [`Precise`](LambertWAccuracyMode::Precise) for 50 bits of accuracy and the [`Simple`](LambertWAccuracyMode::Simple) mode 
 /// for only 24 bits, but with faster execution time.
 /// 
-/// Wrapper of the `lambert_w_m1` and `sp_lambert_w_m1` functions of the `lambert_w` crate.
+/// Wrapper of the `lambert_w_m1` and `sp_lambert_w_m1` functions of the `puruspe` crate.
 /// 
 /// # Reference
 ///
 /// [Toshio Fukushima, Precise and fast computation of Lambert W function by piecewise minimax rational function approximation with variable transformation](https://www.researchgate.net/publication/346309410_Precise_and_fast_computation_of_Lambert_W_function_by_piecewise_minimax_rational_function_approximation_with_variable_transformation)
 pub fn lambert_wm1(z: f64, mode: LambertWAccuracyMode) -> f64 {
     match mode {
-        LambertWAccuracyMode::Precise => lambert_w::lambert_w_m1(z),
-        LambertWAccuracyMode::Simple => lambert_w::sp_lambert_w_m1(z),
+        LambertWAccuracyMode::Precise => puruspe::lambert_wm1(z),
+        LambertWAccuracyMode::Simple => puruspe::sp_lambert_wm1(z),
     }
 }
 

--- a/src/special/mod.rs
+++ b/src/special/mod.rs
@@ -22,7 +22,7 @@
 //!   - Lambert W function (principal branch W₀ and secondary branch W₋₁)
 //! 
 //! Many of these functions are implemented using efficient numerical approximations
-//! or by wrapping functions from other crates (e.g., `puruspe`, `lambert_w`).
+//! or by wrapping functions from other crates (e.g., `puruspe`).
 //! 
 //! The module also includes an enum `LambertWAccuracyMode` to control the
 //! accuracy-speed trade-off for Lambert W function calculations.


### PR DESCRIPTION
Now that we have integrated `lambert_w` into `puruspe`, `peroxide` can directly depend on only `puruspe`. This PR therefore updates to the latest version of `puruspe` with the Lambert W functions and removes the `lambert_w` dependency.

I also edited the documentation to reflect this change.
