### PR TITLE
Add Lambert W function to list of special functions in crate docs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@
 //!   - Error
 //!   - Incomplete Gamma
 //!   - Incomplete Beta
+//!   - Lambert W
 //! - Automatic Differentiation
 //!   - [Taylor mode forward AD](structure/ad/index.html)
 //! - Numerical Utils


### PR DESCRIPTION
I noticed I forgot to add the Lambert W function to the list of special functions in the crate docs!