### PR TITLE
ADD: add default signature for linspace macro

### DIFF
--- a/src/macros/matlab_macro.rs
+++ b/src/macros/matlab_macro.rs
@@ -102,10 +102,25 @@ macro_rules! eye {
 ///     assert_eq!(a, seq!(1,10,1));
 /// }
 /// ```
+/// ```
+/// #[macro_use]
+/// extern crate peroxide;
+/// use peroxide::fuga::*;
+///
+/// fn main() {
+///     let a = linspace!(10, 1000);
+///     assert_eq!(a, seq!(10,1000,10));
+/// }
+/// ```
 #[macro_export]
 macro_rules! linspace {
     ( $start:expr, $end:expr, $length: expr) => {{
         let step = ($end - $start) as f64 / ($length as f64 - 1f64);
+        seq!($start, $end, step)
+    }};
+
+    ( $start:expr, $end:expr ) => {{
+        let step = ($end - $start) as f64 / (99f64);
         seq!($start, $end, step)
     }};
 }


### PR DESCRIPTION
implements #84. added additional syntax rule for `linspace` macro with no `$length` argument - default is to generate 100 points. let me know if i need to provide additional tests and/or docs!