### PR TITLE
Update the `pyo3` dependency to version 0.27.1.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,9 +39,8 @@ peroxide-num = "0.1"
 anyhow = "1.0"
 paste = "1.0"
 netcdf = { version = "0.7", optional = true, default-features = false }
-pyo3 = { version = "0.22", optional = true, features = [
+pyo3 = { version = "0.27.1", optional = true, features = [
   "auto-initialize",
-  "gil-refs",
 ] }
 blas = { version = "0.22", optional = true }
 lapack = { version = "0.19", optional = true }


### PR DESCRIPTION
This way `peroxide` should hopefully compile in CI on the latest OS images when the `plot` feature is enabled, notably in the CI test suite of `puruspe`.