### PR TITLE
Implement Wishart(v, 𝗩) matrix-variate distribution

### DIFF
--- a/src/statistics/dist.rs
+++ b/src/statistics/dist.rs
@@ -1504,7 +1504,6 @@ impl MatRNG for MatDist {
     }
 }
 
-#[cfg_attr(not(feature = "O3"), allow(unused))]
 fn mv_ln_gamma(p: usize, a: f64) -> f64 {
     let p_f64 = p as f64;
 

--- a/src/statistics/dist.rs
+++ b/src/statistics/dist.rs
@@ -241,6 +241,7 @@
 //!     * Mean: $e^{\mu + \frac{\sigma^2}{2}}$
 //!     * Var: $(e^{\sigma^2} - 1)e^{2\mu + \sigma^2}$
 //! * To generate log-normal random samples, Peroxide uses the `rand_distr::LogNormal` distribution from the `rand_distr` crate.
+//!
 //! ### `MVRNG` trait
 //!
 //! * `MVRNG` trait is composed of four fields
@@ -270,8 +271,8 @@
 //! ### Dirichlet Distribution
 //!
 //! * Definition
-//!     $$ \text{Dir}(\mathbf{x} | \boldsymbol{\alpha}) = \frac{1}{\text{B}(\boldsymbol{\alpha})} \prod_{i=1}^K x_i^{\alpha_i - 1} $$
-//!     where $\text{B}(\boldsymbol{\alpha}) = \frac{\prod_{i=1}^K \Gamma(\alpha_i)}{\Gamma(\sum_{i=1}^K \alpha_i)}$
+//!   $$ \text{Dir}(\mathbf{x} | \boldsymbol{\alpha}) = \frac{1}{\text{B}(\boldsymbol{\alpha})} \prod_{i=1}^K x_i^{\alpha_i - 1} $$
+//!   where $\text{B}(\boldsymbol{\alpha}) = \frac{\prod_{i=1}^K \Gamma(\alpha_i)}{\Gamma(\sum_{i=1}^K \alpha_i)}$
 //! * Representative value
 //!     * Mean: $\frac{\alpha_i}{\alpha_0}$
 //!     * Var : $\frac{\alpha_i(\alpha_0 - \alpha_i)}{\alpha_0^2(\alpha_0 + 1)}$
@@ -292,6 +293,68 @@
 //!         a.cov().print();                            // Covariance matrix
 //!     }
 //!     ```
+//!
+//! ### `MatRNG` trait
+//!
+//! * `MatRNG` trait is composed of four fields for Matrix-Variate distributions
+//!     * `sample`: Extract samples
+//!     * `sample_with_rng`: Extract samples with specific rng
+//!     * `pdf` : Calculate pdf value at specific point
+//!     * `ln_pdf` : Calculate log-pdf value at specific point
+//!     ```no_run
+//!     use rand::Rng;
+//!     use peroxide::fuga::*;
+//!
+//!     pub trait MatRNG {
+//!         /// Extract samples of matrix-variate distributions
+//!         fn sample(&self, n: usize) -> Vec<Matrix>;
+//!
+//!         /// Extract samples of distributions with specific rng
+//!         fn sample_with_rng<R: Clone + Rng>(&self, rng: &mut R, n: usize) -> Vec<Matrix>;
+//!
+//!         /// Probability Density Function
+//!         fn pdf(&self, x: &Matrix) -> f64;
+//!
+//!         /// Log Probability Density Function
+//!         fn ln_pdf(&self, x: &Matrix) -> f64;
+//!     }
+//!     ```
+//!
+//! ### Wishart Distribution
+//!
+//! * Definition
+//!   $$ \mathcal{W}_p(\nu, \mathbf{V}) = \frac{|\mathbf{X}|^{(\nu - p - 1)/2} \exp\left(-\frac{1}{2}\text{tr}(\mathbf{V}^{-1}\mathbf{X})\right)}{2^{\nu p / 2} |\mathbf{V}|^{\nu/2} \Gamma_p\left(\frac{\nu}{2}\right)} $$
+//!   where $\nu$ is the degrees of freedom (`df`), $\mathbf{V}$ is the $p \times p$ scale matrix, and $\Gamma_p$ is the multivariate Gamma function.
+//! * Representative value
+//!     * Mean: $\nu \mathbf{V}$
+//!     * Variance: $\nu(V_{ij}^2 + V_{ii}V_{jj})$ (Element-wise)
+//!     * Covariance: $\text{Cov}(X_{ij}, X_{kl}) = \nu(V_{ik}V_{jl} + V_{il}V_{jk})$ (Vectorized to $p^2 \times p^2$)
+//! * To generate Wishart random samples, Peroxide uses the Bartlett Decomposition: $\mathbf{X} = \mathbf{L} \mathbf{A} \mathbf{A}^T \mathbf{L}^T$.
+//! * **Caution**: `MatDist` utilizes the existing `Statistics` trait. Covariance and correlation are returned as flattened $p^2 \times p^2$ matrices.
+//!
+//!     ```rust
+//!     use peroxide::fuga::*;
+//!
+//!     fn main() {
+//!         // Ensure O3 feature is enabled for LAPACK operations
+//!         #[cfg(feature = "O3")]
+//!         {
+//!             let mut rng = smallrng_from_seed(42);
+//!             let scale = matrix(vec![1.0, 0.5, 0.5, 1.0], 2, 2, Row);
+//!             let w = MatDist::Wishart(5.0, scale);       // Wishart(df, V)
+//!             
+//!             w.sample(10)[0].print();                    // Print first sample
+//!             w.sample_with_rng(&mut rng, 10)[0].print(); // Generate with specific rng
+//!             
+//!             let test_x = matrix(vec![2.0, 0.0, 0.0, 2.0], 2, 2, Row);
+//!             w.pdf(&test_x).print();                     // Probability density
+//!             
+//!             w.mean().print();                           // Mean matrix
+//!             w.var().print();                            // Element-wise variance matrix
+//!             w.cov().print();                            // Vectorized p^2 x p^2 covariance
+//!         }
+//!     }
+//!     ```
 
 extern crate rand;
 extern crate rand_distr;
@@ -303,15 +366,18 @@ pub use self::MVDist::*;
 pub use self::OPDist::*;
 pub use self::TPDist::*;
 use crate::special::function::*;
-use crate::traits::fp::FPVector;
+use crate::traits::fp::{FPMatrix, FPVector};
 //use statistics::rand::ziggurat;
 use self::WeightedUniformError::*;
 use crate::statistics::{ops::C, stat::Statistics};
 use crate::structure::matrix::{matrix, Matrix, Row};
-use crate::util::non_macro::{linspace, seq};
+use crate::util::non_macro::{linspace, seq, zeros};
 use crate::util::useful::{auto_zip, find_interval};
 use anyhow::{bail, Result};
 use std::f64::consts::E;
+
+#[cfg(feature = "O3")]
+use crate::traits::matrix::{LinearAlgebra, MatrixTrait, UPLO};
 
 /// One parameter distribution
 ///
@@ -345,6 +411,15 @@ pub enum TPDist<T: PartialOrd + SampleUniform + Copy + Into<f64>> {
 #[derive(Debug, Clone)]
 pub enum MVDist<T: PartialOrd + SampleUniform + Copy + Into<f64>> {
     Dirichlet(Vec<T>),
+}
+
+/// Matrix-Variate Distribution
+///
+/// # Distributions
+/// * `Wishart(df, scale)`: Wishart distribution
+#[derive(Debug, Clone)]
+pub enum MatDist {
+    Wishart(f64, Matrix),
 }
 
 pub struct WeightedUniform<T: PartialOrd + SampleUniform + Copy + Into<f64>> {
@@ -1214,4 +1289,205 @@ impl<T: PartialOrd + SampleUniform + Copy + Into<f64>> MVRNG for MVDist<T> {
             }
         }
     }
+}
+
+/// Matrix-Variate Random Number Generator Trait
+pub trait MatRNG {
+    /// Extract samples of matrix-variate distributions
+    fn sample(&self, n: usize) -> Vec<Matrix> {
+        let mut rng = rand::rng();
+        self.sample_with_rng(&mut rng, n)
+    }
+
+    /// Extract samples of distributions with specific rng
+    fn sample_with_rng<R: Rng + Clone>(&self, rng: &mut R, n: usize) -> Vec<Matrix>;
+
+    /// Probability Density Function
+    fn pdf(&self, x: &Matrix) -> f64 {
+        self.ln_pdf(x).exp()
+    }
+
+    /// Log Probability Density Function
+    fn ln_pdf(&self, x: &Matrix) -> f64;
+}
+
+impl Statistics for MatDist {
+    type Array = Matrix;
+    type Value = Matrix;
+
+    fn mean(&self) -> Self::Value {
+        match self {
+            MatDist::Wishart(df, scale) => scale.clone() * *df,
+        }
+    }
+
+    fn var(&self) -> Self::Value {
+        match self {
+            MatDist::Wishart(df, scale) => {
+                let p = scale.row;
+                let mut v = matrix(vec![0f64; p * p], p, p, Row);
+                for i in 0..p {
+                    for j in 0..p {
+                        v[(i, j)] = *df * (scale[(i, j)].powi(2) + scale[(i, i)] * scale[(j, j)]);
+                    }
+                }
+                v
+            }
+        }
+    }
+
+    fn sd(&self) -> Self::Value {
+        self.var().fmap(|x| x.sqrt())
+    }
+
+    fn cov(&self) -> Self::Array {
+        match self {
+            MatDist::Wishart(df, scale) => {
+                let p = scale.row;
+                let p_sq = p * p;
+
+                // Allocate a flattened p^2 x p^2 covariance matrix
+                let mut cov_mat = zeros(p_sq, p_sq);
+
+                for i in 0..p {
+                    for j in 0..p {
+                        for k in 0..p {
+                            for l in 0..p {
+                                let row_idx = i * p + j;
+                                let col_idx = k * p + l;
+
+                                cov_mat[(row_idx, col_idx)] = *df
+                                    * (scale[(i, k)] * scale[(j, l)]
+                                        + scale[(i, l)] * scale[(j, k)]);
+                            }
+                        }
+                    }
+                }
+                cov_mat
+            }
+        }
+    }
+
+    fn cor(&self) -> Self::Array {
+        let cov_mat = self.cov();
+        let sd_mat = self.sd();
+        let p = sd_mat.row;
+        let p_sq = p * p;
+
+        let mut cor_mat = zeros(p_sq, p_sq);
+
+        for i in 0..p {
+            for j in 0..p {
+                for k in 0..p {
+                    for l in 0..p {
+                        let row_idx = i * p + j;
+                        let col_idx = k * p + l;
+
+                        // Scale the covariance element by the standard deviations
+                        cor_mat[(row_idx, col_idx)] =
+                            cov_mat[(row_idx, col_idx)] / (sd_mat[(i, j)] * sd_mat[(k, l)]);
+                    }
+                }
+            }
+        }
+        cor_mat
+    }
+}
+
+impl MatRNG for MatDist {
+    #[cfg_attr(not(feature = "O3"), allow(unused))]
+    fn sample_with_rng<R: Rng + Clone>(&self, rng: &mut R, n: usize) -> Vec<Matrix> {
+        match self {
+            MatDist::Wishart(df, scale) => {
+                let p = scale.row;
+
+                #[cfg(feature = "O3")]
+                {
+                    // Bartlett Decomposition Requires Cholesky on the Scale Matrix
+                    let l_mat = scale.cholesky(UPLO::Lower);
+                    let mut samples = Vec::with_capacity(n);
+                    let normal = rand_distr::StandardNormal;
+
+                    for _ in 0..n {
+                        let mut a_mat = matrix(vec![0f64; p * p], p, p, Row);
+
+                        // Populate the Bartlett Matrix A
+                        for i in 0..p {
+                            for j in 0..=i {
+                                if i == j {
+                                    let chi = rand_distr::ChiSquared::new(*df - i as f64).unwrap();
+                                    a_mat[(i, i)] = chi.sample(rng).sqrt();
+                                } else {
+                                    a_mat[(i, j)] = rng.sample(normal);
+                                }
+                            }
+                        }
+
+                        // Compute X = L * A * A^T * L^T
+                        let la = &l_mat * &a_mat;
+                        let x = &la * &la.t();
+
+                        samples.push(x);
+                    }
+
+                    samples
+                }
+                #[cfg(not(feature = "O3"))]
+                {
+                    unimplemented!(
+                        "Wishart sampling requires the 'O3' feature for Cholesky decomposition."
+                    );
+                }
+            }
+        }
+    }
+
+    #[cfg_attr(not(feature = "O3"), allow(unused))]
+    fn ln_pdf(&self, x: &Matrix) -> f64 {
+        match self {
+            MatDist::Wishart(df, scale) => {
+                #[cfg(feature = "O3")]
+                {
+                    let p_usize = scale.row;
+                    let p = p_usize as f64;
+
+                    let det_x = x.det();
+                    let det_v = scale.det();
+                    let inv_v = scale.inv();
+
+                    // Trace of (V^-1 * X)
+                    let v_inv_x = &inv_v * x;
+                    let tr_v_inv_x = v_inv_x.diag().iter().sum::<f64>();
+
+                    let term1 = (*df - p - 1.0) / 2.0 * det_x.ln();
+                    let term2 = -0.5 * tr_v_inv_x;
+                    let term3 = -(*df * p) / 2.0 * 2f64.ln();
+                    let term4 = -(*df / 2.0) * det_v.ln();
+                    let term5 = -mv_ln_gamma(p_usize, *df / 2.0);
+
+                    term1 + term2 + term3 + term4 + term5
+                }
+                #[cfg(not(feature = "O3"))]
+                {
+                    unimplemented!("Wishart PDF calculation requires the 'O3' feature for matrix inversion and determinants.");
+                }
+            }
+        }
+    }
+}
+
+#[cfg_attr(not(feature = "O3"), allow(unused))]
+fn mv_ln_gamma(p: usize, a: f64) -> f64 {
+    let p_f64 = p as f64;
+
+    if a <= (p_f64 - 1.0) / 2.0 {
+        return f64::NAN;
+    }
+
+    let mut sum = p_f64 * (p_f64 - 1.0) / 4.0 * std::f64::consts::PI.ln();
+    for j in 1..=p {
+        sum += ln_gamma(a + (1.0 - j as f64) / 2.0);
+    }
+
+    sum
 }

--- a/src/statistics/dist.rs
+++ b/src/statistics/dist.rs
@@ -366,7 +366,10 @@ pub use self::MVDist::*;
 pub use self::OPDist::*;
 pub use self::TPDist::*;
 use crate::special::function::*;
-use crate::traits::fp::{FPMatrix, FPVector};
+use crate::traits::{
+    fp::{FPMatrix, FPVector},
+    matrix::{LinearAlgebra, MatrixTrait},
+};
 //use statistics::rand::ziggurat;
 use self::WeightedUniformError::*;
 use crate::statistics::{ops::C, stat::Statistics};
@@ -377,7 +380,7 @@ use anyhow::{bail, Result};
 use std::f64::consts::E;
 
 #[cfg(feature = "O3")]
-use crate::traits::matrix::{LinearAlgebra, MatrixTrait, UPLO};
+use crate::traits::matrix::UPLO;
 
 /// One parameter distribution
 ///
@@ -1442,35 +1445,60 @@ impl MatRNG for MatDist {
         }
     }
 
-    #[cfg_attr(not(feature = "O3"), allow(unused))]
     fn ln_pdf(&self, x: &Matrix) -> f64 {
         match self {
             MatDist::Wishart(df, scale) => {
-                #[cfg(feature = "O3")]
-                {
-                    let p_usize = scale.row;
-                    let p = p_usize as f64;
+                let p_usize = scale.row;
+                let p = p_usize as f64;
 
-                    let det_x = x.det();
-                    let det_v = scale.det();
-                    let inv_v = scale.inv();
+                assert!(
+                    *df > p - 1.0,
+                    "Degrees of freedom must be greater than p - 1"
+                );
 
-                    // Trace of (V^-1 * X)
-                    let v_inv_x = &inv_v * x;
-                    let tr_v_inv_x = v_inv_x.diag().iter().sum::<f64>();
+                assert_eq!(
+                    x.row, p_usize,
+                    "Input matrix X dimensions must match scale matrix V"
+                );
 
-                    let term1 = (*df - p - 1.0) / 2.0 * det_x.ln();
-                    let term2 = -0.5 * tr_v_inv_x;
-                    let term3 = -(*df * p) / 2.0 * 2f64.ln();
-                    let term4 = -(*df / 2.0) * det_v.ln();
-                    let term5 = -mv_ln_gamma(p_usize, *df / 2.0);
+                assert_eq!(x.col, p_usize, "Input matrix X must be a square matrix");
 
-                    term1 + term2 + term3 + term4 + term5
+                // X must be symmetric and have strictly positive diagonals
+                for i in 0..p_usize {
+                    // A positive definite matrix must have strictly positive diagonal elements
+                    if x[(i, i)] <= 0f64 {
+                        return std::f64::NEG_INFINITY;
+                    }
+
+                    for j in 0..i {
+                        if (x[(i, j)] - x[(j, i)]).abs() > 1e-7 {
+                            return std::f64::NEG_INFINITY;
+                        }
+                    }
                 }
-                #[cfg(not(feature = "O3"))]
-                {
-                    unimplemented!("Wishart PDF calculation requires the 'O3' feature for matrix inversion and determinants.");
+
+                // X must have a positive determinant
+                let det_x = x.det();
+                if det_x <= 0f64 {
+                    return std::f64::NEG_INFINITY;
                 }
+
+                let det_v = scale.det();
+                assert!(det_v > 0f64, "Scale matrix V must be positive definite");
+
+                let inv_v = scale.inv();
+
+                // Trace of (V^-1 * X)
+                let v_inv_x = &inv_v * x;
+                let tr_v_inv_x = v_inv_x.diag().iter().sum::<f64>();
+
+                let term1 = (*df - p - 1.0) / 2.0 * det_x.ln();
+                let term2 = -0.5 * tr_v_inv_x;
+                let term3 = -(*df * p) / 2.0 * 2f64.ln();
+                let term4 = -(*df / 2.0) * det_v.ln();
+                let term5 = -mv_ln_gamma(p_usize, *df / 2.0);
+
+                term1 + term2 + term3 + term4 + term5
             }
         }
     }

--- a/src/util/print.rs
+++ b/src/util/print.rs
@@ -326,6 +326,62 @@ impl Printable for Matrix {
     }
 }
 
+impl Printable for Vec<Matrix> {
+    fn print(&self) {
+        if self.is_empty() {
+            println!("[]");
+            return;
+        }
+
+        println!("[");
+
+        for i in 0..self.len() {
+            let mat_str = self[i].to_string();
+            let indented = mat_str
+                .lines()
+                .map(|line| format!("  {}", line))
+                .collect::<Vec<_>>()
+                .join("\n");
+
+            if i != self.len() - 1 {
+                println!("{},\n", indented);
+            } else {
+                println!("{}", indented);
+            }
+        }
+
+        println!("]");
+    }
+}
+
+impl Printable for &Vec<Matrix> {
+    fn print(&self) {
+        if self.is_empty() {
+            println!("[]");
+            return;
+        }
+
+        println!("[");
+
+        for i in 0..self.len() {
+            let mat_str = self[i].to_string();
+            let indented = mat_str
+                .lines()
+                .map(|line| format!("  {}", line))
+                .collect::<Vec<_>>()
+                .join("\n");
+
+            if i != self.len() - 1 {
+                println!("{},\n", indented);
+            } else {
+                println!("{}", indented);
+            }
+        }
+
+        println!("]");
+    }
+}
+
 impl Printable for Polynomial {
     fn print(&self) {
         println!("{}", self);
@@ -375,6 +431,13 @@ impl<T: Debug + PartialOrd + SampleUniform + Copy + Into<f64>> Printable for TPD
 
 #[cfg(feature = "rand")]
 impl<T: Debug + PartialOrd + SampleUniform + Copy + Into<f64>> Printable for MVDist<T> {
+    fn print(&self) {
+        println!("{:?}", self);
+    }
+}
+
+#[cfg(feature = "rand")]
+impl Printable for MatDist {
     fn print(&self) {
         println!("{:?}", self);
     }

--- a/src/util/print.rs
+++ b/src/util/print.rs
@@ -356,29 +356,7 @@ impl Printable for Vec<Matrix> {
 
 impl Printable for &Vec<Matrix> {
     fn print(&self) {
-        if self.is_empty() {
-            println!("[]");
-            return;
-        }
-
-        println!("[");
-
-        for i in 0..self.len() {
-            let mat_str = self[i].to_string();
-            let indented = mat_str
-                .lines()
-                .map(|line| format!("  {}", line))
-                .collect::<Vec<_>>()
-                .join("\n");
-
-            if i != self.len() - 1 {
-                println!("{},\n", indented);
-            } else {
-                println!("{}", indented);
-            }
-        }
-
-        println!("]");
+        (*self).print();
     }
 }
 

--- a/tests/dist.rs
+++ b/tests/dist.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "rand")]
 
-extern crate peroxide;
+use peroxide::c;
 use peroxide::fuga::*;
 
 #[test]
@@ -28,4 +28,102 @@ fn test_dirichlet() {
 
     let pdf_val = dir.pdf(&[0.33333, 0.33333, 0.33333]);
     assert!(nearly_eq(pdf_val, 2.222155556222205));
+}
+
+#[test]
+fn test_wishart() {
+    #[cfg(feature = "O3")]
+    {
+        // Define Scale Matrix V:
+        // [ 1.0  0.5 ]
+        // [ 0.5  1.0 ]
+        let scale = matrix(c!(1.0, 0.5, 0.5, 1.0), 2, 2, Row);
+
+        // Wishart with 5 degrees of freedom
+        let w = MatDist::Wishart(5.0, scale);
+
+        // Test Sampling
+        let samples = w.sample(10);
+        samples.print();
+        assert_eq!(samples.len(), 10);
+        assert_eq!(samples[0].nrow(), 2);
+        assert_eq!(samples[0].ncol(), 2);
+
+        // Test Mean (E[X] = df * V)
+        let m = w.mean();
+        assert!(nearly_eq(m[(0, 0)], 5.0));
+        assert!(nearly_eq(m[(0, 1)], 2.5));
+        assert!(nearly_eq(m[(1, 0)], 2.5));
+        assert!(nearly_eq(m[(1, 1)], 5.0));
+
+        // Test Variance (Element-wise: Var(X_ij) = df * (V_ij^2 + V_ii * V_jj))
+        let v = w.var();
+        assert!(nearly_eq(v[(0, 0)], 10.0)); // 5 * (1^2 + 1*1)
+        assert!(nearly_eq(v[(0, 1)], 6.25)); // 5 * (0.5^2 + 1*1) = 5 * 1.25
+        assert!(nearly_eq(v[(1, 0)], 6.25));
+        assert!(nearly_eq(v[(1, 1)], 10.0));
+
+        // Test Covariance (Vectorized 4x4 matrix)
+        // Cov(X_ij, X_kl) = df * (V_ik * V_jl + V_il * V_jk)
+        let cov = w.cov();
+        assert_eq!(cov.nrow(), 4);
+        assert_eq!(cov.ncol(), 4);
+
+        // Cov(X_00, X_00) -> mapped to index (0, 0)
+        assert!(nearly_eq(cov[(0, 0)], 10.0));
+
+        // Cov(X_00, X_11) -> mapped to index (0, 3)
+        // 5 * (V_01 * V_01 + V_01 * V_01) = 5 * (0.25 + 0.25) = 2.5
+        assert!(nearly_eq(cov[(0, 3)], 2.5));
+
+        // Cov(X_01, X_01) -> mapped to index (1, 1)
+        // 5 * (V_00 * V_11 + V_01 * V_10) = 5 * (1 + 0.25) = 6.25
+        assert!(nearly_eq(cov[(1, 1)], 6.25));
+
+        // Cov(X_01, X_10) -> mapped to index (1, 2)
+        // 5 * (V_01 * V_10 + V_00 * V_11) = 5 * (0.25 + 1.0) = 6.25
+        assert!(nearly_eq(cov[(1, 2)], 6.25));
+
+        // 5. Test PDF against an exact closed-form calculation
+        // Let test_x = [ 2.0  0.0 ]
+        //              [ 0.0  2.0 ]
+        let test_x = matrix(c!(2.0, 0.0, 0.0, 2.0), 2, 2, Row);
+        let pdf_val = w.pdf(&test_x);
+
+        // Exact closed-form math for this specific test case:
+        // Numerator:   |X|^1 * exp(-0.5 * tr(V^-1 * X)) = 4 * exp(-8/3)
+        // Denominator: 2^5 * |V|^2.5 * Gamma_2(2.5) = 32 * (0.75)^2.5 * (0.75 * pi)
+        // Which simplifies cleanly to: 16 * exp(-8/3) / (27 * sqrt(3) * pi)
+        let expected_pdf =
+            16.0 * (-8.0f64 / 3.0).exp() / (27.0 * 3.0f64.sqrt() * std::f64::consts::PI);
+
+        assert!(nearly_eq(pdf_val, expected_pdf));
+    }
+}
+
+#[test]
+fn test_wishart_1d_chi_square() {
+    #[cfg(feature = "O3")]
+    {
+        let df = 5.0;
+        let scale = matrix(c!(1.0), 1, 1, Row);
+        let w = MatDist::Wishart(df, scale);
+
+        // A Chi-Square(df) distribution has Mean = df, Variance = 2*df
+        let m = w.mean();
+        let v = w.var();
+
+        assert!(nearly_eq(m[(0, 0)], df));
+        assert!(nearly_eq(v[(0, 0)], 2.0 * df));
+
+        // Check PDF Convergence
+        let x_val = 3.0;
+        let test_x = matrix(c!(x_val), 1, 1, Row);
+        let wishart_pdf = w.pdf(&test_x);
+
+        let chi_pdf = (x_val.powf(df / 2.0 - 1.0) * (-x_val / 2.0).exp())
+            / (2.0f64.powf(df / 2.0) * gamma(df / 2.0));
+
+        assert!(nearly_eq(wishart_pdf, chi_pdf));
+    }
 }

--- a/tests/dist.rs
+++ b/tests/dist.rs
@@ -127,3 +127,80 @@ fn test_wishart_1d_chi_square() {
         assert!(nearly_eq(wishart_pdf, chi_pdf));
     }
 }
+
+#[test]
+fn test_wishart_support_and_invalid_inputs() {
+    let scale = matrix(c!(1.0, 0.5, 0.5, 1.0), 2, 2, Row);
+    let w = MatDist::Wishart(5.0, scale);
+
+    // x = -I (Negative Definite) -> ln_pdf should be -inf, pdf should be 0
+    let test_x_neg = matrix(c!(-1.0, 0.0, 0.0, -1.0), 2, 2, Row);
+    assert_eq!(w.ln_pdf(&test_x_neg), std::f64::NEG_INFINITY);
+    assert_eq!(w.pdf(&test_x_neg), 0.0);
+
+    // x = Asymmetric -> ln_pdf should be -inf
+    let test_x_asym = matrix(c!(1.0, 0.8, 0.2, 1.0), 2, 2, Row);
+    assert_eq!(w.ln_pdf(&test_x_asym), std::f64::NEG_INFINITY);
+}
+
+#[test]
+#[should_panic]
+fn test_wishart_invalid_df_panic() {
+    // df = 0.5, but p = 2. This is invalid and should panic
+    let scale = matrix(c!(1.0, 0.0, 0.0, 1.0), 2, 2, Row);
+    let w = MatDist::Wishart(0.5, scale);
+
+    // We only need a valid SPD matrix to pass the bounds check and trigger the df panic
+    let test_x = matrix(c!(1.0, 0.0, 0.0, 1.0), 2, 2, Row);
+    w.ln_pdf(&test_x);
+}
+
+#[test]
+fn test_wishart_reproducibility() {
+    #[cfg(feature = "O3")]
+    {
+        let mut rng1 = smallrng_from_seed(42);
+        let mut rng2 = smallrng_from_seed(42);
+
+        let scale = matrix(c!(1.0, 0.5, 0.5, 1.0), 2, 2, Row);
+        let w = MatDist::Wishart(5.0, scale);
+
+        let s1 = w.sample_with_rng(&mut rng1, 1);
+        let s2 = w.sample_with_rng(&mut rng2, 1);
+
+        for i in 0..2 {
+            for j in 0..2 {
+                assert_eq!(s1[0][(i, j)], s2[0][(i, j)]);
+            }
+        }
+    }
+}
+
+#[test]
+fn test_wishart_empirical_convergence() {
+    #[cfg(feature = "O3")]
+    {
+        let mut rng = smallrng_from_seed(42);
+        let scale = matrix(c!(1.0, 0.5, 0.5, 1.0), 2, 2, Row);
+        let w = MatDist::Wishart(5.0, scale);
+
+        let n_samples = 10_000;
+        let samples = w.sample_with_rng(&mut rng, n_samples);
+
+        let mut emp_mean = zeros(2, 2);
+        for s in &samples {
+            emp_mean = &emp_mean + s;
+        }
+
+        let n_f64 = n_samples as f64;
+        let theo_mean = w.mean();
+
+        // Ensure empirical mean is within a small epsilon of theoretical mean
+        for i in 0..2 {
+            for j in 0..2 {
+                emp_mean[(i, j)] /= n_f64;
+                assert!((emp_mean[(i, j)] - theo_mean[(i, j)]).abs() < 0.1);
+            }
+        }
+    }
+}

--- a/tests/dist.rs
+++ b/tests/dist.rs
@@ -184,22 +184,73 @@ fn test_wishart_empirical_convergence() {
         let scale = matrix(c!(1.0, 0.5, 0.5, 1.0), 2, 2, Row);
         let w = MatDist::Wishart(5.0, scale);
 
-        let n_samples = 10_000;
+        let n_samples = 20_000;
         let samples = w.sample_with_rng(&mut rng, n_samples);
 
-        let mut emp_mean = zeros(2, 2);
+        let p = 2;
+        let p_sq = p * p;
+        let n_f64 = n_samples as f64;
+
+        let mut emp_mean = zeros(p, p);
         for s in &samples {
             emp_mean = &emp_mean + s;
         }
 
-        let n_f64 = n_samples as f64;
+        for i in 0..p {
+            for j in 0..p {
+                emp_mean[(i, j)] /= n_f64;
+            }
+        }
+
+        let mut emp_cov = zeros(p_sq, p_sq);
+        for s in &samples {
+            for i in 0..p {
+                for j in 0..p {
+                    for k in 0..p {
+                        for l in 0..p {
+                            let row_idx = i * p + j;
+                            let col_idx = k * p + l;
+
+                            let diff1 = s[(i, j)] - emp_mean[(i, j)];
+                            let diff2 = s[(k, l)] - emp_mean[(k, l)];
+
+                            emp_cov[(row_idx, col_idx)] += diff1 * diff2;
+                        }
+                    }
+                }
+            }
+        }
+
+        for i in 0..p_sq {
+            for j in 0..p_sq {
+                emp_cov[(i, j)] /= n_f64 - 1.0;
+            }
+        }
+
         let theo_mean = w.mean();
+        let theo_cov = w.cov();
 
         // Ensure empirical mean is within a small epsilon of theoretical mean
-        for i in 0..2 {
-            for j in 0..2 {
-                emp_mean[(i, j)] /= n_f64;
-                assert!((emp_mean[(i, j)] - theo_mean[(i, j)]).abs() < 0.1);
+        for i in 0..p {
+            for j in 0..p {
+                assert!(
+                    (emp_mean[(i, j)] - theo_mean[(i, j)]).abs() < 0.1,
+                    "Mean failed to converge at ({}, {})",
+                    i,
+                    j
+                );
+            }
+        }
+
+        // We have a slightly higher epsilon as covariance uses higher moments
+        for i in 0..p_sq {
+            for j in 0..p_sq {
+                assert!(
+                    (emp_cov[(i, j)] - theo_cov[(i, j)]).abs() < 0.5,
+                    "Covariance failed to converge at ({}, {})",
+                    i,
+                    j
+                );
             }
         }
     }


### PR DESCRIPTION
This implements the [Wishart Distribution](https://en.wikipedia.org/wiki/Wishart_distribution) or $\mathcal{W}_p (\nu, \mathbf{V})$, enabling matrix-variate statistical modeling.

Sampling is implemented via the Bartlett decomposition ($\mathbf{X} = \mathbf{L} \mathbf{A} \mathbf{A}^T \mathbf{L}^T$). This provides a numerically stable and efficient way to draw samples using the Cholesky factor of the scale matrix rather than using matrix multiplication.

Further, because the covariance of a Wishart distribution is a 4th-order tensor, this implementation flattens the result into a $p^2 \times p^2$ `Matrix` in order to allow us to stay within the existing `Statistics` trait's design constraints while providing full covariance/correlation information.

Results have been verified with `scipy.stats.wishart`.