### PR TITLE
Replace CONTRIBUTING.md source layout table with docs.rs pointer (JOSS #99)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,21 +41,8 @@ Peroxide follows the [Gitflow workflow]. A few practical rules:
 
 ## Source layout
 
-A high-level map of `src/`; see each module's `mod.rs` and the [API docs](https://docs.rs/peroxide) for details.
-
-| Module | Purpose |
-| ------------------ | ------------------------------------------------------------------ |
-| [`structure`](src/structure) | Core data structures: `Matrix`, `Vec<f64>` extensions, `DataFrame`, `Polynomial`, `Jet<N>` forward AD |
-| [`numerical`](src/numerical) | Numerical algorithms: ODE solvers, integration, interpolation, splines, root finding, optimization, eigenvalues |
-| [`statistics`](src/statistics) | Probability distributions, RNG wrappers, ordered statistics |
-| [`complex`](src/complex) | Complex vectors, matrices, and integrals (`complex` feature) |
-| [`special`](src/special) | Special functions (wrapper of `puruspe`) |
-| [`traits`](src/traits) | Shared trait definitions (math, functional programming, pointers) |
-| [`macros`](src/macros) | R / MATLAB / Julia style macros |
-| [`fuga`](src/fuga), [`prelude`](src/prelude) | The two user-facing import styles (explicit vs simple) |
-| [`util`](src/util) | Constructors, printing, plotting, low-level helpers |
-| [`ml`](src/ml) | Basic machine learning tools (beta) |
-| [`grave`](src/grave) | Retired implementations kept for reference; not compiled |
+The directories under `src/` map one-to-one to the public modules, so the module index in the [API docs](https://docs.rs/peroxide) doubles as the source map; start from a module's documentation and its `mod.rs`.
+The only exception is `src/grave/`, which holds retired implementations kept for reference and is excluded from compilation.
 
 ## Code of conduct
 

--- a/src/complex/mod.rs
+++ b/src/complex/mod.rs
@@ -1,3 +1,5 @@
+//! Complex vectors, matrices, and integrals, enabled by the `complex` feature
+
 use num_complex::Complex;
 
 pub type C64 = Complex<f64>;

--- a/src/macros/mod.rs
+++ b/src/macros/mod.rs
@@ -1,4 +1,4 @@
-//! Useful macros
+//! R / MATLAB / Julia style macros
 
 pub mod julia_macro;
 pub mod matlab_macro;

--- a/src/ml/mod.rs
+++ b/src/ml/mod.rs
@@ -1,3 +1,3 @@
-//! Machine learning tools
+//! Basic machine learning tools (beta)
 
 pub mod reg;

--- a/src/numerical/mod.rs
+++ b/src/numerical/mod.rs
@@ -1,4 +1,4 @@
-//! Differential equations & Numerical Analysis tools
+//! Numerical algorithms: ODE solvers, quadrature, interpolation, splines, root finding, optimization, and eigenvalue computation
 
 pub mod eigen;
 pub mod integral;

--- a/src/statistics/mod.rs
+++ b/src/statistics/mod.rs
@@ -1,4 +1,4 @@
-//! Statistical Modules
+//! Probability distributions, random sampling, and statistical operations
 //!
 //! * Basic statistical tools - `stat.rs`
 //! * Popular distributions - `dist.rs` (`rand` feature)

--- a/src/structure/mod.rs
+++ b/src/structure/mod.rs
@@ -1,8 +1,8 @@
-//! Main structures for peroxide
+//! Core data structures: `Matrix`, `Vec<f64>` extensions, `DataFrame`, `Polynomial`, and const-generic forward-mode AD (`Jet<N>`)
 //!
-//! * Matrix
+//! * Matrix (dense & sparse)
 //! * Vector
-//! * Automatic derivatives
+//! * Automatic differentiation (`Jet<N>`)
 //! * Polynomial
 //! * DataFrame
 //! * Multinomial (not yet implemented)

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -1,3 +1,5 @@
+//! Shared trait definitions: mathematics, functional programming, mutability, pointers, and numeric abstractions
+
 pub mod float;
 pub mod fp;
 pub mod general;

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,4 +1,4 @@
-//! Utility - plot, print, pickle and etc.
+//! Utilities: constructors, printing, plotting, and low-level helpers
 
 pub mod api;
 pub mod non_macro;


### PR DESCRIPTION
Follow-up to the remaining question in #99.

The trimmed module table in CONTRIBUTING.md was still a hand-maintained mirror of the source structure, so it could only drift out of sync as modules change. But simply deleting it would have lost information: `complex` and `traits` had no module docs at all, and several module doc first lines ("Useful macros", "Statistical Modules", "Main structures for peroxide") were too vague to serve as an index.

So instead of keeping a curated copy, the descriptions now live where rustdoc picks them up:

- each module's one-line purpose moved into its own `mod.rs` (`//!` docs), with new module docs for `complex` and `traits`
- the CONTRIBUTING.md table is replaced by a two-sentence pointer: `src/` directories map one-to-one to the public modules, so the docs.rs module index doubles as the source map
- the only repo-only fact rustdoc cannot show stays in CONTRIBUTING.md: `src/grave/` is retired code excluded from compilation

The module descriptions are now reviewed together with the code they describe, so there is no separate structure document left to fall out of sync.