### PR TITLE
FIX: Make ln_gamma exact at small integers and gamma(-0.0) negative infinity

### DIFF
--- a/src/special/lanczos.rs
+++ b/src/special/lanczos.rs
@@ -27,6 +27,15 @@ pub fn ln_gamma_approx(z: f64) -> f64 {
         return f64::INFINITY;
     }
 
+    // Positive integers up to 23 go through gamma_approx, whose factorial path is
+    // exact there (22! is the largest factorial representable in f64). This makes
+    // ln_gamma(1) and ln_gamma(2) return exactly 0 instead of about -1e-11, which
+    // matters for callers that subtract two log-gammas of equal argument. The bound
+    // keeps the branch cheap enough to stay on the hot path.
+    if z <= 23.0 && z.fract() == 0.0 {
+        return gamma_approx(z).ln();
+    }
+
     if z < 0.5 {
         return PI.ln() - (PI * z).sin().abs().ln() - ln_gamma_approx(1.0 - z);
     }
@@ -44,7 +53,13 @@ pub fn ln_gamma_approx(z: f64) -> f64 {
 pub fn gamma_approx(z: f64) -> f64 {
     if z <= 0.0 && z.fract() == 0.0 {
         if z == 0.0 {
-            return f64::INFINITY;
+            // tgamma(+0.0) is +inf and tgamma(-0.0) is -inf (C99, and what scipy
+            // returns). Plain `z == 0.0` matches both zeros, so branch on the sign.
+            return if z.is_sign_negative() {
+                f64::NEG_INFINITY
+            } else {
+                f64::INFINITY
+            };
         } else {
             return f64::NAN;
         }

--- a/tests/special.rs
+++ b/tests/special.rs
@@ -1,5 +1,5 @@
 use peroxide::fuga::{LambertWAccuracyMode::*, *};
-use std::f64::consts::PI;
+use std::f64::consts::{LN_2, PI};
 
 #[test]
 fn lambert_w_test() {
@@ -13,6 +13,11 @@ fn test_gamma_poles_and_undefined() {
     assert!(gamma(0.0).is_infinite());
     assert!(gamma(0.0).is_sign_positive());
 
+    // Gamma(-0.0) diverges to negative infinity: tgamma(+0.0) is +inf and
+    // tgamma(-0.0) is -inf in C99, and `z == 0.0` matches both zeros.
+    assert!(gamma(-0.0).is_infinite());
+    assert!(gamma(-0.0).is_sign_negative());
+
     // Gamma for negative integers is mathematically undefined (diverges)
     assert!(gamma(-1.0).is_nan());
     assert!(gamma(-2.0).is_nan());
@@ -22,6 +27,8 @@ fn test_gamma_poles_and_undefined() {
     assert!(ln_gamma(0.0).is_infinite());
     assert!(ln_gamma(-1.0).is_infinite());
     assert!(ln_gamma(-10.0).is_infinite());
+    assert!(ln_gamma(-0.0).is_infinite());
+    assert!(ln_gamma(-0.0).is_sign_positive());
 }
 
 #[test]
@@ -103,6 +110,69 @@ fn test_ln_gamma_consistency() {
             val,
             expected,
             actual
+        );
+    }
+}
+
+#[test]
+fn test_ln_gamma_exact_at_small_integers() {
+    // Gamma(1) = Gamma(2) = 1, so the log is exactly zero. The Lanczos series on
+    // its own lands near -5e-12 here, and that leaks into any caller that forms a
+    // difference of log-gammas, such as a log-space binomial coefficient.
+    assert_eq!(ln_gamma(1.0), 0.0);
+    assert_eq!(ln_gamma(2.0), 0.0);
+
+    // Reference values computed with mpmath at 40 digits, rounded to f64. The
+    // tolerance is tight enough to fail if the integer path is removed, since the
+    // Lanczos series alone is only good to about 4e-13 relative here.
+    let cases: [(f64, f64); 3] = [
+        (3.0, LN_2),
+        (16.0, 27.89927138384089),
+        (23.0, 48.47118135183523),
+    ];
+
+    for &(z, expected) in &cases {
+        let got = ln_gamma(z);
+        let rel = (got - expected).abs() / expected.abs();
+        assert!(
+            rel < 1e-14,
+            "ln_gamma({}) = {}, expected {}, relative error {:e}",
+            z,
+            got,
+            expected,
+            rel
+        );
+    }
+}
+
+#[test]
+fn test_ln_gamma_against_reference() {
+    // Independent reference values (mpmath, 40 digits, rounded to f64).
+    // test_ln_gamma_consistency compares ln_gamma against gamma().ln(), which is
+    // circular for non-integer z >= 0.5 because gamma is ln_gamma(z).exp() there,
+    // so these pin the actual values instead. Note nearly_eq compares magnitudes
+    // and cannot catch a sign flip, hence the explicit signed comparison.
+    let cases: [(f64, f64); 8] = [
+        (0.5, 0.5723649429247001),
+        (1.5, -0.12078223763524522),
+        (2.5, 0.2846828704729192),
+        (10.5, 13.940625219403763),
+        (-0.5, 1.2655121234846454),
+        (-1.5, 0.860047015376481),
+        (-2.5, -0.056243716497674054),
+        (-10.5, -15.147270590717842),
+    ];
+
+    for &(z, expected) in &cases {
+        let got = ln_gamma(z);
+        let tol = 1e-9 * expected.abs().max(1.0);
+        assert!(
+            (got - expected).abs() <= tol,
+            "ln_gamma({}) = {}, expected {} (tolerance {:e})",
+            z,
+            got,
+            expected,
+            tol
         );
     }
 }


### PR DESCRIPTION
Follow-up to #105, covering the three items I flagged when merging it.

## `ln_gamma` is now exact at small integers

`ln_gamma_approx` routed every argument through the Lanczos series, so `ln_gamma(1)` and `ln_gamma(2)` came back as `-5.2e-12` and `-1.0e-11` where both are exactly zero. #105 gave `gamma_approx` an exact factorial path for positive integers, so `ln_gamma_approx` can borrow it. The bound is `z <= 23`, since `22!` is the largest factorial representable in `f64`, which keeps the branch short enough to stay on the hot path.

Absolute error at integer arguments drops from about 1e-11 to 1e-16:

| | before | after | reference (mpmath) |
|---|---|---|---|
| `ln_gamma(1)` | -5.232259070453438e-12 | **0** | 0 |
| `ln_gamma(2)` | -1.035438401686406e-11 | **0** | 0 |
| `ln_gamma(3)` | 0.6931471805460543 | 0.6931471805599453 | `LN_2` |
| `ln_gamma(16)` | 27.899271383829813 | 27.89927138384089 | 27.89927138384089 |

This matters beyond cosmetics. Any caller that subtracts two log-gammas of equal argument inherits the error, and #112 does exactly that for its log-space binomial coefficient. On a local merge of this branch with #112:

```
Binomial(5,   0.0).pdf(0.0)  1.00000000000523226 -> 1.0 exactly
Binomial(0,   0.5).pdf(0.0)  1.00000000000523226 -> 1.0 exactly
Binomial(10,  0.3).pdf(0.0)  rel err 5.2e-12     -> 7.4e-16
Binomial(10,  0.3).pdf(3.0)  rel err 1.8e-11     -> 2.1e-16
sum of pmf over support       1 + 1.6e-11        -> 1 - 5.6e-16
```

The `pmf > 1` case is closed for every `n`, not only for `n <= 22`, because it only arose at `m = 0` and `m = n` where `ln_c` reduces to `-ln_gamma(1)`.

## `gamma(-0.0)` is negative infinity again

The pole branch added in #105 matches negative zero through `z == 0.0` and returns `+inf`. C99 `tgamma` and scipy both give `-inf`, and the reflection path it replaced returned `-inf` too, since it evaluated `PI / (sin(-0.0) * gamma(1.0))`. So this restores the previous value rather than inventing a convention.

## Tests

- `gamma(-0.0)` and `ln_gamma(-0.0)` assertions folded into `test_gamma_poles_and_undefined`.
- `test_ln_gamma_exact_at_small_integers` pins `ln_gamma(1)` and `ln_gamma(2)` to exact zero and checks three mpmath reference values to 1e-14 relative, tight enough to fail if the integer path is removed (the Lanczos series alone is only good to about 4e-13 there).
- `test_ln_gamma_against_reference` adds eight mpmath values across both branches. `test_ln_gamma_consistency` compares `ln_gamma` against `gamma().ln()`, which is circular for non-integer `z >= 0.5` because `gamma` is `ln_gamma(z).exp()` there, so it cannot detect systematic drift in the Lanczos core. This one can. It is coverage rather than a regression test for this patch, and it passes both with and without the source change. It also compares signed values directly, since `nearly_eq` compares magnitudes and would not catch a sign flip.

Both behavior changes were checked against a reverted source tree: `test_gamma_poles_and_undefined` fails on `assertion failed: gamma(-0.0).is_sign_negative()` and `test_ln_gamma_exact_at_small_integers` fails with `left: -5.232259070453438e-12, right: 0.0`.

## No regression elsewhere

A 304-point sweep of `gamma` and `ln_gamma` (integers 1 to 25 plus 30/50/100/170/171/172, a non-integer grid over [0.5, 30], and 39 negative points) shows the only values that move are `gamma(-0.0)` and `ln_gamma` at positive integers up to 23. Everything else, including the whole negative half and all non-integer arguments, is bit-identical to the current `dev`.

Locally: `cargo test` clean including the 255 doctests, `cargo fmt --all --check` clean, `cargo clippy --all-targets` back to the pre-existing 45 warnings with none in the touched files.
