### PR TITLE
Release v0.43.1

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -33,6 +33,10 @@ authors:
     family-names: Sen
     affiliation: Independent Researcher
     orcid: 'https://orcid.org/0009-0008-0337-9964'
+  - given-names: Russell R P
+    family-names: Senthamarai
+    affiliation: Independent Researcher
+    orcid: 'https://orcid.org/0000-0002-8061-5480'
   - given-names: Johanna
     family-names: Sörngård
     affiliation: Independent Researcher

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -69,4 +69,4 @@ keywords:
   - Integration
   - Linear algebra
   - Differential equation
-license: MIT OR Apache-2.0
+license: MIT

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "peroxide"
-version = "0.43.0"
+version = "0.43.1"
 authors = ["axect <axect@outlook.kr>"]
 edition = "2018"
 description = "Rust comprehensive scientific computation library contains linear algebra, numerical analysis, statistics and machine learning tools with familiar syntax"

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,25 @@
+# Release 0.43.1 (2026-08-02)
+
+## Bug fixes
+
+- Improve numerical stability and domain coverage of `gamma_approx` and `ln_gamma_approx` ([#105](https://github.com/Axect/Peroxide/pull/105)) (Thanks to [@jzeuzs](https://github.com/jzeuzs))
+  - `ln_gamma_approx` now applies Euler's reflection formula for `z < 0.5`, which previously only `gamma_approx` did.
+  - Poles are handled explicitly: `gamma_approx` returns `NaN` at negative integers and `ln_gamma_approx` returns `+inf` at non-positive integers.
+  - The positive-integer fast path accumulates in `f64` instead of the integer `factorial` helper, and saturates to `+inf` above `z = 171`.
+  - Adds 171 lines of tests covering poles, reflection, integer arguments and large-magnitude inputs.
+- Make `ln_gamma` exact at small integers and `gamma(-0.0)` negative infinity ([#113](https://github.com/Axect/Peroxide/pull/113))
+  - Integer arguments up to 23 route through the exact factorial path, so `ln_gamma_approx(1.0)` and `ln_gamma_approx(2.0)` return exactly `0` instead of about `-1e-11`. This matters for callers that subtract two log-gammas of equal argument.
+  - `gamma_approx(-0.0)` returns `-inf` while `gamma_approx(0.0)` returns `+inf`, matching C99 `tgamma` and SciPy.
+
+## JOSS review (#10366) cycle
+
+### Metadata
+- Add Russell R P Senthamarai to `CITATION.cff` and the manuscript author list. The manuscript and `CITATION.cff` now list the same eight named authors in the same order with matching ORCIDs.
+- Use a single SPDX identifier for the `CITATION.cff` `license` field. `MIT OR Apache-2.0` is an SPDX expression, which the Citation File Format 1.2.0 schema does not accept. Zenodo validates the file with cffconvert during GitHub release archiving, so the v0.42.0 and v0.43.0 archives failed and never received a DOI. The array form is valid per the CFF spec but Zenodo has rejected it since the InvenioRDM migration ([zenodo/zenodo#2515](https://github.com/zenodo/zenodo/issues/2515)). The crate stays dual-licensed under MIT or Apache-2.0 through `Cargo.toml` and the two `LICENSE-*` files.
+
+### Documentation
+- Apply editorial wording fixes to the manuscript ([#114](https://github.com/Axect/Peroxide/pull/114)) (Thanks to [@jbytecode](https://github.com/jbytecode))
+
 # Release 0.43.0 (2026-07-11)
 
 ## Breaking changes

--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -163,8 +163,7 @@
   edition   = {3rd},
   publisher = {Cambridge University Press},
   year      = {2007},
-  isbn      = {978-0-521-88068-8},
-  doi       = {10.1080/00401706.1987.10488304}
+  isbn      = {978-0-521-88068-8}
 }
 
 % ===== Python ecosystem references =====

--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -163,7 +163,8 @@
   edition   = {3rd},
   publisher = {Cambridge University Press},
   year      = {2007},
-  isbn      = {978-0-521-88068-8}
+  isbn      = {978-0-521-88068-8},
+  doi       = {10.1080/00401706.1987.10488304}
 }
 
 % ===== Python ecosystem references =====

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -27,6 +27,9 @@ authors:
   - name: Soumya Sen
     orcid: 0009-0008-0337-9964
     affiliation: 4
+  - name: Russell R P Senthamarai
+    orcid: 0000-0002-8061-5480
+    affiliation: 4
   - name: Johanna Sörngård
     orcid: 0000-0002-8660-9989
     affiliation: 4

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -80,11 +80,11 @@ Peroxide fills this integration gap.
 | DataFrame I/O       | $\checkmark$        | —       | —       | —    | —        | —      | —        | $\checkmark$      |
 
 We do not claim superiority over any specialist crate within its domain.
-Peroxide's contribution is the integration itself, enabled by design abstractions: a `ButcherTableau` trait unifies Runge-Kutta methods via compile-time constants, a `Calculus` trait supports exact differentiation and integration of piecewise polynomial splines, const-generic typing constrains root-finding dimensions, and a `Real` trait carries AD-derived derivatives into optimization and root-finding without glue code.
+Peroxide's contribution is the integration itself, enabled by design abstractions: a `ButcherTableau` trait unifies Runge-Kutta methods via compile-time constants, a `Calculus` trait supports exact differentiation and integration of piecewise polynomial splines, const generic typing constrains root-finding dimensions, and a `Real` trait carries AD-derived derivatives into optimization and root-finding without glue code.
 
 # State of the field
 
-In automatic differentiation specifically, a review of available Rust AD crates on crates.io indicates that, to our knowledge, Peroxide is the only library combining const-generic derivative order, normalized Taylor coefficient storage, and true Taylor-mode propagation with $O(N^2)$ cost per elementary operation.
+In automatic differentiation specifically, a review of available Rust AD crates on crates.io indicates that, to our knowledge, Peroxide is the only library combining const generic derivative order, normalized Taylor coefficient storage, and true Taylor-mode propagation with $O(N^2)$ cost per elementary operation.
 Most alternatives provide dual numbers up to second or third order with fixed type hierarchies [@numdual] or nested generics with exponential cost at higher orders [@autodiff_elrnv].
 The ad-trait crate [@adtrait] offers both forward and reverse modes but is limited to first-order derivatives.
 Enzyme [@enzyme] performs AD as an LLVM compiler pass and supports both forward and reverse modes.
@@ -98,11 +98,11 @@ Peroxide's `ButcherTableau` trait-based architecture is a complementary approach
 **Architecture.**
 We store matrices as a flat `Vec<f64>` with a `Shape` enum (`Row`/`Col`) that controls logical layout without copying data.
 This design trades the rich type-level dimensionality of nalgebra for a memory model that maps directly to both the pure-Rust `matrixmultiply` crate [@matrixmultiply] and, when the `O3` feature flag is enabled, to OpenBLAS [@openblas], passing raw pointers with stride and transpose flags without intermediate type conversions.
-The trade-offs are that matrix dimensions are not enforced at compile time (unlike nalgebra's typed `Matrix<f64, R, C>`) and the layout does not extend to N-dimensional tensors as `ndarray` [@ndarray] does.
+The trade-offs are that matrix dimensions are not enforced at compile time (unlike nalgebra's typed `Matrix<f64, R, C>`), and the layout does not extend to N-dimensional tensors as `ndarray` [@ndarray] does.
 A `Real` trait abstracts over `f64` and `AD` (= `Jet<2>`), so the same function can compute both values and derivatives.
 
 **Automatic differentiation.**
-The const-generic type `Jet<N>` stores the function value $c_0 = f(a)$ and $N$ normalized Taylor coefficients $c_k = f^{(k)}(a)/k!$ [@griewank2008].
+The const generic type `Jet<N>` stores the function value $c_0 = f(a)$ and $N$ normalized Taylor coefficients $c_k = f^{(k)}(a)/k!$ [@griewank2008].
 Multiplication follows the Cauchy product of truncated power series:
 
 $$c_n(f \cdot g) = \sum_{i=0}^{n} c_i(f)\, c_{n-i}(g)$$

--- a/src/special/lanczos.rs
+++ b/src/special/lanczos.rs
@@ -23,6 +23,10 @@ const LG5N7: [f64; 7] = [
 ];
 
 pub fn ln_gamma_approx(z: f64) -> f64 {
+    if z < 0.5 {
+        return PI.ln() - (PI * z).sin().abs().ln() - ln_gamma_approx(1.0 - z);
+    }
+
     let z = z - 1f64;
     let base = z + G + 0.5;
     let mut s = 0f64;

--- a/src/special/lanczos.rs
+++ b/src/special/lanczos.rs
@@ -23,6 +23,10 @@ const LG5N7: [f64; 7] = [
 ];
 
 pub fn ln_gamma_approx(z: f64) -> f64 {
+    if z <= 0.0 && z.fract() == 0.0 {
+        return f64::INFINITY;
+    }
+    
     if z < 0.5 {
         return PI.ln() - (PI * z).sin().abs().ln() - ln_gamma_approx(1.0 - z);
     }

--- a/src/special/lanczos.rs
+++ b/src/special/lanczos.rs
@@ -1,6 +1,6 @@
 //! Lanczos approximation Coefficient generator
 
-use crate::statistics::ops::{double_factorial, factorial, C};
+use crate::statistics::ops::{double_factorial, C};
 use crate::structure::matrix::Matrix;
 use crate::traits::matrix::MatrixTrait;
 use crate::traits::pointer::{Oxide, RedoxCommon};
@@ -50,7 +50,7 @@ pub fn gamma_approx(z: f64) -> f64 {
         }
     }
 
-    if z > 1.0 && z.fract() == 0.0 {
+    if z > 0.0 && z.fract() == 0.0 {
         let mut result = 1.0;
         let n = (z - 1.0) as u64;
         for i in 2..=n {

--- a/src/special/lanczos.rs
+++ b/src/special/lanczos.rs
@@ -26,7 +26,7 @@ pub fn ln_gamma_approx(z: f64) -> f64 {
     if z <= 0.0 && z.fract() == 0.0 {
         return f64::INFINITY;
     }
-    
+
     if z < 0.5 {
         return PI.ln() - (PI * z).sin().abs().ln() - ln_gamma_approx(1.0 - z);
     }
@@ -42,18 +42,19 @@ pub fn ln_gamma_approx(z: f64) -> f64 {
 }
 
 pub fn gamma_approx(z: f64) -> f64 {
-    if z > 1f64 {
-        let z_int = z as usize;
-        if z - (z_int as f64) == 0f64 {
-            return factorial(z_int - 1) as f64;
+    if z <= 0.0 && z.fract() == 0.0 {
+        if z == 0.0 {
+            return f64::INFINITY;
+        } else {
+            return f64::NAN;
         }
     }
 
     if z < 0.5 {
-        PI / ((PI * z).sin() * gamma_approx(1f64 - z))
-    } else {
-        ln_gamma_approx(z).exp()
+        return PI / ((PI * z).sin() * gamma_approx(1f64 - z));
     }
+
+    ln_gamma_approx(z).exp()
 }
 
 /// Lanczos Approximation Coefficient

--- a/src/special/lanczos.rs
+++ b/src/special/lanczos.rs
@@ -50,6 +50,16 @@ pub fn gamma_approx(z: f64) -> f64 {
         }
     }
 
+    if z > 1.0 && z.fract() == 0.0 {
+        let mut result = 1.0;
+        let n = (z - 1.0) as u64;
+        for i in 2..=n {
+            result *= i as f64;
+        }
+
+        return result;
+    }
+
     if z < 0.5 {
         return PI / ((PI * z).sin() * gamma_approx(1f64 - z));
     }

--- a/src/special/lanczos.rs
+++ b/src/special/lanczos.rs
@@ -51,6 +51,10 @@ pub fn gamma_approx(z: f64) -> f64 {
     }
 
     if z > 0.0 && z.fract() == 0.0 {
+        if z > 171.0 {
+            return f64::INFINITY;
+        }
+
         let mut result = 1.0;
         let n = (z - 1.0) as u64;
         for i in 2..=n {

--- a/src/special/lanczos.rs
+++ b/src/special/lanczos.rs
@@ -27,6 +27,15 @@ pub fn ln_gamma_approx(z: f64) -> f64 {
         return f64::INFINITY;
     }
 
+    // Positive integers up to 23 go through gamma_approx, whose factorial path is
+    // exact there (22! is the largest factorial representable in f64). This makes
+    // ln_gamma(1) and ln_gamma(2) return exactly 0 instead of about -1e-11, which
+    // matters for callers that subtract two log-gammas of equal argument. The bound
+    // keeps the branch cheap enough to stay on the hot path.
+    if z <= 23.0 && z.fract() == 0.0 {
+        return gamma_approx(z).ln();
+    }
+
     if z < 0.5 {
         return PI.ln() - (PI * z).sin().abs().ln() - ln_gamma_approx(1.0 - z);
     }
@@ -44,7 +53,13 @@ pub fn ln_gamma_approx(z: f64) -> f64 {
 pub fn gamma_approx(z: f64) -> f64 {
     if z <= 0.0 && z.fract() == 0.0 {
         if z == 0.0 {
-            return f64::INFINITY;
+            // tgamma(+0.0) is +inf and tgamma(-0.0) is -inf (C99, and what scipy
+            // returns). Plain `z == 0.0` matches both zeros, so branch on the sign.
+            return if z.is_sign_negative() {
+                f64::NEG_INFINITY
+            } else {
+                f64::INFINITY
+            };
         } else {
             return f64::NAN;
         }

--- a/tests/special.rs
+++ b/tests/special.rs
@@ -1,7 +1,108 @@
 use peroxide::fuga::{LambertWAccuracyMode::*, *};
+use std::f64::consts::PI;
 
 #[test]
 fn lambert_w_test() {
     assert_eq!(lambert_w0(1.0, Precise), 0.567143290409784);
     assert!(nearly_eq(lambert_w0(1.0, Simple), 0.567143290409784));
+}
+
+#[test]
+fn test_gamma_poles_and_undefined() {
+    // Gamma(0) approaches infinity
+    assert!(gamma(0.0).is_infinite());
+    assert!(gamma(0.0).is_sign_positive());
+
+    // Gamma for negative integers is mathematically undefined (diverges)
+    assert!(gamma(-1.0).is_nan());
+    assert!(gamma(-2.0).is_nan());
+    assert!(gamma(-10.0).is_nan());
+
+    // Log-Gamma goes to positive infinity for all poles
+    assert!(ln_gamma(0.0).is_infinite());
+    assert!(ln_gamma(-1.0).is_infinite());
+    assert!(ln_gamma(-10.0).is_infinite());
+}
+
+#[test]
+fn test_gamma_integer_fast_path() {
+    // Standard small factorials: Gamma(n) = (n-1)!
+    assert_eq!(gamma(1.0), 1.0); // 0!
+    assert_eq!(gamma(2.0), 1.0); // 1!
+    assert_eq!(gamma(4.0), 6.0); // 3!
+    assert_eq!(gamma(5.0), 24.0); // 4!
+    assert_eq!(gamma(10.0), 362_880.0); // 9!
+
+    // Wolfram Alpha high-precision check (21!)
+    // f64 can exactly represent this without precision loss
+    assert_eq!(gamma(22.0), 51_090_942_171_709_440_000.0);
+
+    // Maximum limit of f64 float representation (~171.6)
+    // Ensure it doesn't panic on overflow, but correctly yields Infinity
+    assert!(gamma(172.0).is_infinite());
+}
+
+#[test]
+fn test_gamma_positive_floats() {
+    let sqrt_pi = PI.sqrt();
+
+    // Gamma(0.5) = sqrt(PI)
+    assert!(nearly_eq(gamma(0.5), sqrt_pi));
+
+    // Gamma(1.5) = 0.5 * sqrt(PI)
+    assert!(nearly_eq(gamma(1.5), 0.5 * sqrt_pi));
+
+    // Gamma(2.5) = 1.329340388179...
+    assert!(nearly_eq(gamma(2.5), 0.75 * sqrt_pi));
+}
+
+#[test]
+fn test_gamma_negative_floats_reflection() {
+    let sqrt_pi = PI.sqrt();
+
+    // Gamma(-0.5) = -2 * sqrt(PI)
+    // This validates that .abs() is NOT used on the sine in gamma_approx
+    assert!(nearly_eq(gamma(-0.5), -2.0 * sqrt_pi));
+    assert!(gamma(-0.5).is_sign_negative());
+
+    // Gamma(-1.5) = (4/3) * sqrt(PI)
+    assert!(nearly_eq(gamma(-1.5), (4.0 / 3.0) * sqrt_pi));
+    assert!(gamma(-1.5).is_sign_positive());
+
+    // Gamma(-2.5) = -(8/15) * sqrt(PI)
+    assert!(nearly_eq(gamma(-2.5), -(8.0 / 15.0) * sqrt_pi));
+    assert!(gamma(-2.5).is_sign_negative());
+}
+
+#[test]
+fn test_ln_gamma_consistency() {
+    // ln_gamma(x) should equal ln(|Gamma(x)|) across the board
+    let test_values = vec![0.5, 1.5, 2.5, 10.5];
+
+    for &val in &test_values {
+        let expected = gamma(val).ln();
+        let actual = ln_gamma(val);
+        assert!(
+            nearly_eq(expected, actual),
+            "Failed at positive float: val={}, expected={}, actual={}",
+            val,
+            expected,
+            actual
+        );
+    }
+
+    // Test Negative Floats to ensure `.abs()` prevents NaN
+    let negative_test_values = vec![-0.5, -1.5, -2.5, -10.5];
+
+    for &val in &negative_test_values {
+        let expected = gamma(val).abs().ln();
+        let actual = ln_gamma(val);
+        assert!(
+            nearly_eq(expected, actual),
+            "Failed at negative float: val={}, expected={}, actual={}",
+            val,
+            expected,
+            actual
+        );
+    }
 }

--- a/tests/special.rs
+++ b/tests/special.rs
@@ -1,5 +1,5 @@
 use peroxide::fuga::{LambertWAccuracyMode::*, *};
-use std::f64::consts::PI;
+use std::f64::consts::{LN_2, PI};
 
 #[test]
 fn lambert_w_test() {
@@ -13,6 +13,11 @@ fn test_gamma_poles_and_undefined() {
     assert!(gamma(0.0).is_infinite());
     assert!(gamma(0.0).is_sign_positive());
 
+    // Gamma(-0.0) diverges to negative infinity: tgamma(+0.0) is +inf and
+    // tgamma(-0.0) is -inf in C99, and `z == 0.0` matches both zeros.
+    assert!(gamma(-0.0).is_infinite());
+    assert!(gamma(-0.0).is_sign_negative());
+
     // Gamma for negative integers is mathematically undefined (diverges)
     assert!(gamma(-1.0).is_nan());
     assert!(gamma(-2.0).is_nan());
@@ -22,6 +27,8 @@ fn test_gamma_poles_and_undefined() {
     assert!(ln_gamma(0.0).is_infinite());
     assert!(ln_gamma(-1.0).is_infinite());
     assert!(ln_gamma(-10.0).is_infinite());
+    assert!(ln_gamma(-0.0).is_infinite());
+    assert!(ln_gamma(-0.0).is_sign_positive());
 }
 
 #[test]
@@ -103,6 +110,69 @@ fn test_ln_gamma_consistency() {
             val,
             expected,
             actual
+        );
+    }
+}
+
+#[test]
+fn test_ln_gamma_exact_at_small_integers() {
+    // Gamma(1) = Gamma(2) = 1, so the log is exactly zero. The Lanczos series on
+    // its own lands near -5e-12 here, and that leaks into any caller that forms a
+    // difference of log-gammas, such as a log-space binomial coefficient.
+    assert_eq!(ln_gamma(1.0), 0.0);
+    assert_eq!(ln_gamma(2.0), 0.0);
+
+    // Reference values computed with mpmath at 40 digits, rounded to f64. The
+    // tolerance is tight enough to fail if the integer path is removed, since the
+    // Lanczos series alone is only good to about 4e-13 relative here.
+    let cases: [(f64, f64); 3] = [
+        (3.0, LN_2),
+        (16.0, 27.89927138384089),
+        (23.0, 48.47118135183523),
+    ];
+
+    for &(z, expected) in &cases {
+        let got = ln_gamma(z);
+        let rel = (got - expected).abs() / expected.abs();
+        assert!(
+            rel < 1e-14,
+            "ln_gamma({}) = {}, expected {}, relative error {:e}",
+            z,
+            got,
+            expected,
+            rel
+        );
+    }
+}
+
+#[test]
+fn test_ln_gamma_against_reference() {
+    // Independent reference values (mpmath, 40 digits, rounded to f64).
+    // test_ln_gamma_consistency compares ln_gamma against gamma().ln(), which is
+    // circular for non-integer z >= 0.5 because gamma is ln_gamma(z).exp() there,
+    // so these pin the actual values instead. Note nearly_eq compares magnitudes
+    // and cannot catch a sign flip, hence the explicit signed comparison.
+    let cases: [(f64, f64); 8] = [
+        (0.5, 0.5723649429247001),
+        (1.5, -0.12078223763524522),
+        (2.5, 0.2846828704729192),
+        (10.5, 13.940625219403763),
+        (-0.5, 1.2655121234846454),
+        (-1.5, 0.860047015376481),
+        (-2.5, -0.056243716497674054),
+        (-10.5, -15.147270590717842),
+    ];
+
+    for &(z, expected) in &cases {
+        let got = ln_gamma(z);
+        let tol = 1e-9 * expected.abs().max(1.0);
+        assert!(
+            (got - expected).abs() <= tol,
+            "ln_gamma({}) = {}, expected {} (tolerance {:e})",
+            z,
+            got,
+            expected,
+            tol
         );
     }
 }


### PR DESCRIPTION
## Summary

Release the current `dev` line as v0.43.1. No public API changes, so this is a patch release.

- Fix pole handling, reflection and integer fast paths in `gamma_approx` / `ln_gamma_approx` (#105, #113).
- Add Russell R P Senthamarai to `CITATION.cff` and the JOSS manuscript author list.
- Fix the `CITATION.cff` `license` field, which was an SPDX expression that the Citation File Format 1.2.0 schema rejects. Zenodo validates this file during GitHub release archiving, which is why the v0.42.0 and v0.43.0 archives failed and never got a DOI.
- Apply the JOSS editorial wording fixes from #114.

## Verification

- `cargo fmt --all --check`
- `cargo test` (255 doc tests + all integration targets pass)
- `cargo test --no-default-features`
- `cargo clippy --all-targets`
- `cffconvert --validate` on `CITATION.cff`: valid against schema 1.2.0
- `paper.md` and `CITATION.cff` list the same eight named authors in the same order with matching ORCIDs