### PR TITLE
Sync v0.43.1 release metadata back to dev

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -33,6 +33,10 @@ authors:
     family-names: Sen
     affiliation: Independent Researcher
     orcid: 'https://orcid.org/0009-0008-0337-9964'
+  - given-names: Russell R P
+    family-names: Senthamarai
+    affiliation: Independent Researcher
+    orcid: 'https://orcid.org/0000-0002-8061-5480'
   - given-names: Johanna
     family-names: Sörngård
     affiliation: Independent Researcher

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -69,4 +69,4 @@ keywords:
   - Integration
   - Linear algebra
   - Differential equation
-license: MIT OR Apache-2.0
+license: MIT

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "peroxide"
-version = "0.43.0"
+version = "0.43.1"
 authors = ["axect <axect@outlook.kr>"]
 edition = "2018"
 description = "Rust comprehensive scientific computation library contains linear algebra, numerical analysis, statistics and machine learning tools with familiar syntax"

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,25 @@
+# Release 0.43.1 (2026-08-02)
+
+## Bug fixes
+
+- Improve numerical stability and domain coverage of `gamma_approx` and `ln_gamma_approx` ([#105](https://github.com/Axect/Peroxide/pull/105)) (Thanks to [@jzeuzs](https://github.com/jzeuzs))
+  - `ln_gamma_approx` now applies Euler's reflection formula for `z < 0.5`, which previously only `gamma_approx` did.
+  - Poles are handled explicitly: `gamma_approx` returns `NaN` at negative integers and `ln_gamma_approx` returns `+inf` at non-positive integers.
+  - The positive-integer fast path accumulates in `f64` instead of the integer `factorial` helper, and saturates to `+inf` above `z = 171`.
+  - Adds 171 lines of tests covering poles, reflection, integer arguments and large-magnitude inputs.
+- Make `ln_gamma` exact at small integers and `gamma(-0.0)` negative infinity ([#113](https://github.com/Axect/Peroxide/pull/113))
+  - Integer arguments up to 23 route through the exact factorial path, so `ln_gamma_approx(1.0)` and `ln_gamma_approx(2.0)` return exactly `0` instead of about `-1e-11`. This matters for callers that subtract two log-gammas of equal argument.
+  - `gamma_approx(-0.0)` returns `-inf` while `gamma_approx(0.0)` returns `+inf`, matching C99 `tgamma` and SciPy.
+
+## JOSS review (#10366) cycle
+
+### Metadata
+- Add Russell R P Senthamarai to `CITATION.cff` and the manuscript author list. The manuscript and `CITATION.cff` now list the same eight named authors in the same order with matching ORCIDs.
+- Use a single SPDX identifier for the `CITATION.cff` `license` field. `MIT OR Apache-2.0` is an SPDX expression, which the Citation File Format 1.2.0 schema does not accept. Zenodo validates the file with cffconvert during GitHub release archiving, so the v0.42.0 and v0.43.0 archives failed and never received a DOI. The array form is valid per the CFF spec but Zenodo has rejected it since the InvenioRDM migration ([zenodo/zenodo#2515](https://github.com/zenodo/zenodo/issues/2515)). The crate stays dual-licensed under MIT or Apache-2.0 through `Cargo.toml` and the two `LICENSE-*` files.
+
+### Documentation
+- Apply editorial wording fixes to the manuscript ([#114](https://github.com/Axect/Peroxide/pull/114)) (Thanks to [@jbytecode](https://github.com/jbytecode))
+
 # Release 0.43.0 (2026-07-11)
 
 ## Breaking changes

--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -163,8 +163,7 @@
   edition   = {3rd},
   publisher = {Cambridge University Press},
   year      = {2007},
-  isbn      = {978-0-521-88068-8},
-  doi       = {10.1080/00401706.1987.10488304}
+  isbn      = {978-0-521-88068-8}
 }
 
 % ===== Python ecosystem references =====

--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -163,7 +163,8 @@
   edition   = {3rd},
   publisher = {Cambridge University Press},
   year      = {2007},
-  isbn      = {978-0-521-88068-8}
+  isbn      = {978-0-521-88068-8},
+  doi       = {10.1080/00401706.1987.10488304}
 }
 
 % ===== Python ecosystem references =====

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -27,6 +27,9 @@ authors:
   - name: Soumya Sen
     orcid: 0009-0008-0337-9964
     affiliation: 4
+  - name: Russell R P Senthamarai
+    orcid: 0000-0002-8061-5480
+    affiliation: 4
   - name: Johanna Sörngård
     orcid: 0000-0002-8660-9989
     affiliation: 4

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -80,11 +80,11 @@ Peroxide fills this integration gap.
 | DataFrame I/O       | $\checkmark$        | —       | —       | —    | —        | —      | —        | $\checkmark$      |
 
 We do not claim superiority over any specialist crate within its domain.
-Peroxide's contribution is the integration itself, enabled by design abstractions: a `ButcherTableau` trait unifies Runge-Kutta methods via compile-time constants, a `Calculus` trait supports exact differentiation and integration of piecewise polynomial splines, const-generic typing constrains root-finding dimensions, and a `Real` trait carries AD-derived derivatives into optimization and root-finding without glue code.
+Peroxide's contribution is the integration itself, enabled by design abstractions: a `ButcherTableau` trait unifies Runge-Kutta methods via compile-time constants, a `Calculus` trait supports exact differentiation and integration of piecewise polynomial splines, const generic typing constrains root-finding dimensions, and a `Real` trait carries AD-derived derivatives into optimization and root-finding without glue code.
 
 # State of the field
 
-In automatic differentiation specifically, a review of available Rust AD crates on crates.io indicates that, to our knowledge, Peroxide is the only library combining const-generic derivative order, normalized Taylor coefficient storage, and true Taylor-mode propagation with $O(N^2)$ cost per elementary operation.
+In automatic differentiation specifically, a review of available Rust AD crates on crates.io indicates that, to our knowledge, Peroxide is the only library combining const generic derivative order, normalized Taylor coefficient storage, and true Taylor-mode propagation with $O(N^2)$ cost per elementary operation.
 Most alternatives provide dual numbers up to second or third order with fixed type hierarchies [@numdual] or nested generics with exponential cost at higher orders [@autodiff_elrnv].
 The ad-trait crate [@adtrait] offers both forward and reverse modes but is limited to first-order derivatives.
 Enzyme [@enzyme] performs AD as an LLVM compiler pass and supports both forward and reverse modes.
@@ -98,11 +98,11 @@ Peroxide's `ButcherTableau` trait-based architecture is a complementary approach
 **Architecture.**
 We store matrices as a flat `Vec<f64>` with a `Shape` enum (`Row`/`Col`) that controls logical layout without copying data.
 This design trades the rich type-level dimensionality of nalgebra for a memory model that maps directly to both the pure-Rust `matrixmultiply` crate [@matrixmultiply] and, when the `O3` feature flag is enabled, to OpenBLAS [@openblas], passing raw pointers with stride and transpose flags without intermediate type conversions.
-The trade-offs are that matrix dimensions are not enforced at compile time (unlike nalgebra's typed `Matrix<f64, R, C>`) and the layout does not extend to N-dimensional tensors as `ndarray` [@ndarray] does.
+The trade-offs are that matrix dimensions are not enforced at compile time (unlike nalgebra's typed `Matrix<f64, R, C>`), and the layout does not extend to N-dimensional tensors as `ndarray` [@ndarray] does.
 A `Real` trait abstracts over `f64` and `AD` (= `Jet<2>`), so the same function can compute both values and derivatives.
 
 **Automatic differentiation.**
-The const-generic type `Jet<N>` stores the function value $c_0 = f(a)$ and $N$ normalized Taylor coefficients $c_k = f^{(k)}(a)/k!$ [@griewank2008].
+The const generic type `Jet<N>` stores the function value $c_0 = f(a)$ and $N$ normalized Taylor coefficients $c_k = f^{(k)}(a)/k!$ [@griewank2008].
 Multiplication follows the Cauchy product of truncated power series:
 
 $$c_n(f \cdot g) = \sum_{i=0}^{n} c_i(f)\, c_{n-i}(g)$$


### PR DESCRIPTION
Back-merge of the v0.43.1 release branch into `dev`, matching the flow used for v0.43.0 (#109 / #110).

Carries the version bump, the `RELEASES.md` entry, the `CITATION.cff` fixes and the JOSS paper branch merge. The `gamma_approx` / `ln_gamma_approx` work (#105, #113) already lives in `dev`, so only the release-side commits are new here.

Companion PR to master: #115