### PR TITLE
Match CITATION.cff title and author list to the JOSS manuscript

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@
 # Visit https://bit.ly/cffinit to generate yours today!
 
 cff-version: 1.2.0
-title: Peroxide
+title: "Peroxide: A Batteries-Included Numerical Computing Library for Rust"
 message: >-
   If you use this software, please cite it using the
   metadata from this file.
@@ -41,7 +41,6 @@ authors:
     family-names: Sörngård
     affiliation: Independent Researcher
     orcid: 'https://orcid.org/0000-0002-8660-9989'
-  - name: Peroxide contributors
 identifiers:
   - type: doi
     value: 10.5281/zenodo.10815823


### PR DESCRIPTION
The handling editor flagged that the archived release metadata does not match the paper (openjournals/joss-reviews#10366).

Zenodo builds the archive metadata from `CITATION.cff`, and two fields were off:

- `title` was the bare crate name instead of the manuscript title.
- The author list carried a trailing `Peroxide contributors` entity entry, so the archive had nine creators against the manuscript's eight.

The paper's Acknowledgements section already credits past and present contributors, so removing the entity entry loses no attribution.

The published v0.43.1 record was corrected by hand since metadata edits do not change the DOI. This commit keeps future releases aligned.

Verified with `cffconvert --validate` (valid against schema 1.2.0) and the Zenodo mapping now yields the manuscript title with exactly eight creators, each with an ORCID.