### PR TITLE
Match CITATION.cff title and author list to the JOSS manuscript (master)

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@
 # Visit https://bit.ly/cffinit to generate yours today!
 
 cff-version: 1.2.0
-title: Peroxide
+title: "Peroxide: A Batteries-Included Numerical Computing Library for Rust"
 message: >-
   If you use this software, please cite it using the
   metadata from this file.
@@ -41,7 +41,6 @@ authors:
     family-names: Sörngård
     affiliation: Independent Researcher
     orcid: 'https://orcid.org/0000-0002-8660-9989'
-  - name: Peroxide contributors
 identifiers:
   - type: doi
     value: 10.5281/zenodo.10815823


### PR DESCRIPTION
Same change as #117, applied to `master` so the repository citation widget and the next release archive both carry the manuscript title and the eight-author list.

Metadata only, no code changes.