### PR TITLE
Sync v0.43.1 archive DOI to dev

### DIFF
--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -5,8 +5,8 @@
   version      = {0.43.1},
   year         = {2026},
   publisher    = {Zenodo},
-  doi          = {10.5281/zenodo.10815823},
-  url          = {https://github.com/Axect/Peroxide}
+  doi          = {10.5281/zenodo.21754256},
+  url          = {https://github.com/Axect/Peroxide/tree/v0.43.1}
 }
 
 % ===== Papers citing Peroxide =====


### PR DESCRIPTION
Mirrors `e50c903` on `features/joss-paper`.

The `peroxide` bibliography entry declared `version = {0.43.1}` while its DOI was the Zenodo concept DOI, which always resolves to the newest deposit. The two would disagree as soon as v0.44.0 ships, and the sentence carrying that citation appeals to reproducibility. The entry now points at the v0.43.1 deposit (`10.5281/zenodo.21754256`) so the reference, the JOSS archive field, and the version tag all name the same artifact.

Docs only. Verified by building the manuscript locally with `openjournals/inara`: the reference renders as "... (Version 0.43.1). Zenodo. https://doi.org/10.5281/zenodo.21754256", and the concept DOI no longer appears anywhere in the PDF.